### PR TITLE
#48 prototypes/list-rendering

### DIFF
--- a/.claude/.steering/20260712-list-rerender-optimization/design.md
+++ b/.claude/.steering/20260712-list-rerender-optimization/design.md
@@ -1,0 +1,63 @@
+# list-rerender-optimization
+
+## 目的
+
+`src/prototypes/rendering/` で「リスト表示で、いずれかの要素が変更 (名前変更など) された際、変更対象要素のみ再描画する」実装を検証する。stage-04 の残課題「操作のたびに stage 全体が再レンダリングされている」の解決策の proof-of-concept として着手。独立したコミットしない施策 (stories として作成、検証後は git 管理下に置かない)。
+
+## 背景・制約
+
+- 依頼: 「変更対象要素のみ再描画される実装を作りたい。独立したコミットしない施策として stories を作成する」
+- 検証手段: Storybook (目視) + jsdom + @testing-library/react の一時テストファイル (`__verify__.test.tsx`)。確認後は毎回削除 (コミットしない方針のため)
+- vitest 実行時、標準の `vitest.config.ts` に `NEXT_PUBLIC_API_URL=http://localhost:3000` を渡せば動く。setupFiles を外した一時 config は不要 (一度不要な回り道をした、個人 memory にも記録: `vitest-temp-verify-env`)
+- `__mocks__/zustand.ts` は `create`/`createStore` のみモック、`useStore` は未対応。zustand vanilla store + `useStore` パターンのテストは `vi.unmock('zustand')` が必要
+
+## 実装計画
+
+- [x] list-01: useState + memo で「変更要素のみ再描画」を検証 (入れ物自体の再描画が残課題と判明)
+- [x] list-01 削除 (ユーザー判断)
+- [x] list-02: zustand vanilla store + Context で「入れ物」の再描画も抑止
+- [x] list-02 拡張: 行追加機能 (ids/byId 分離、構造変更時のみ入れ物が再描画される設計)
+- [x] AddItemForm: uncontrolled input 化、タイピング連打時の再描画を根絶
+- [x] Highlight updates の信頼性検証 (DevTools 表示と console.log ベースの実測の食い違いを切り分け)
+
+## 決定事項
+
+### list-01 → list-02 の設計転換
+
+- list-01: `List01` コンポーネント自身が `useState` で items を保持。`ListItem` を `memo` + イミュータブルな配列更新 (変更要素のみ新オブジェクト化) でラップすることで、**変更要素のみ再描画**は実現できた。
+- しかし `List01` (入れ物) 自体は `setItems` のたびに関数が再実行される。React の原則上、state を持つコンポーネントは更新のたびに必ず再実行されるため、これは `useState` を使う限り不可避。`useReducer` に変えても同じコンポーネント内 state である限り解消しない。
+- 解決策: state を **zustand vanilla store** (`createStore`) に外出しし、Context 経由で store インスタンス (不変の参照) のみを配布する。`List02` 自体は store を購読しないか、購読する場合も「変化しない部分」だけを選択的に購読することで、再描画を制御できる。
+
+### list-02 の normalized state 設計
+
+```ts
+type ListState = {
+  ids: string[]
+  byId: Record<string, ListItemData>
+  renameItem: (id: string, name: string) => void
+  addItem: (item: ListItemData) => void
+}
+```
+
+- `ids` (リスト構造) と `byId` (要素本体) を分離。
+- `renameItem` は `byId` のみ更新 → `ids` の参照は不変 → `ids` を購読する `List02` は名前変更で再描画されない。
+- `addItem` は `ids` を新しい配列に置き換える → `ids` を購読する `List02` は行追加時のみ再描画される。これは新規 JSX 要素をツリーに挿す以上避けられない (Reactの原則)。ただし既存の `ListItem` は `memo` のおかげで `id` (不変 props) により再描画されず、新規追加分のみレンダーされる。
+- 各 `ListItem` は `useListStore(state => state.byId[id])` で自分の分だけ直接購読。`renameItem` も直接呼ぶため、`List02` 経由の props バケツリレーが不要。
+
+### AddItemForm の uncontrolled化
+
+- 当初 `useState` + `value`/`onChange` の controlled input だった。タイピングのたびに `AddItemForm` 自体が再描画されるのは自然な挙動だが、「連打で再描画が連続するのを防ぎたい」という要望に対応するため `useRef` の uncontrolled input に変更。
+- submit 時のみ `inputRef.current.value` を読んで `addItem` を呼び、`inputRef.current.value = ''` で DOM を直接クリア。タイピング中は React の再描画が一切発生しない (ブラウザネイティブの input が自前で値を保持する)。
+
+### Highlight updates の信頼性 (誤解しやすい重要な知見)
+
+- React DevTools の "Highlight updates when components render" は、実際のコンポーネント関数実行 (真の再描画) より **粒度が粗い**。
+- `React.memo` でバイルアウトする場合でも、Fiber の reconciliation 処理 (props 比較のための `beginWork` 通過) 自体は発生することがあり、DevTools はこれを拾って highlight することがある。
+- 確実な判定手段は `console.log` をコンポーネント本体の先頭に置くこと (関数が実際に実行されれば必ず出力される)。
+- 実際の調査過程: 「input 入力中に ListItem 群も highlight される」という報告があったが、console.log ベースの検証 (jsdom + 実ブラウザ両方) では入力中は `AddItemForm` のログしか出ず、`ListItem` のログは一切出なかった。→ DevTools の表示上の癖であり、実際の再描画は発生していないと確定。
+- **今後、React の再描画有無を判定する際は Highlight updates を一次情報にせず、console.log か Profiler タブの実測 (render time / did-not-render 記録) で裏取りする。**
+
+## 懸念・リスク
+
+- `src/prototypes/rendering/list-02/` はコミットしない方針の検証コード。正式に本実装へ反映する場合は、stage-04 などの本番プロトタイプへ設計パターンを移植する形で再実装する必要がある (list-02 のファイルをそのまま昇格させない)。
+- normalized state (ids/byId 分離) は要素の追加・変更のみ検証済み。削除・並べ替えは未検証。

--- a/src/prototypes/list-rendering/README.md
+++ b/src/prototypes/list-rendering/README.md
@@ -1,0 +1,41 @@
+# list-rendering/
+
+リストの再描画最適化の検証を格納する。
+
+- 独立したコミットしない施策として作成 (stage-04 の「操作のたびに stage 全体が再レンダリングされている」課題への proof-of-concept)。
+- 検証詳細は `.claude/.steering/20260712-list-rerender-optimization/design.md` 参照。
+- 当初 useState 版のプロトタイプ (最初期の試作) も作ったが、下記の課題が判明したため削除済み。以降の説明は現存する list-01 から始まる。
+
+## 「入れ物」の再描画抑止 (list-01)
+
+「変更対象要素のみ再描画」自体は `useState` (親) + `React.memo` (子) + イミュータブルな配列更新で実現できる。\
+しかし「入れ物」コンポーネント自体は `useState` を持つ限り、更新のたびに必ず再実行される (React の原則、避けられない)。
+
+解決策: state を zustand vanilla store (`createStore`) に外出しし、Context 経由で store インスタンス (不変の参照) のみ配布する (list-01)。\
+子コンポーネントは各々 `useListStore(state => state.byId[id])` で自分の分だけ直接購読する。
+
+## normalized state の設計
+
+- `ids: string[]` (リスト構造) と `byId: Record<id, Data>` (要素本体) を分離する。
+- 値変更 (rename 等) は `byId` のみ更新 → `ids` 不変 → `ids` を購読する「入れ物」は再描画されない。
+- 構造変更 (追加・削除) は `ids` を更新 → 「入れ物」の再描画は避けられない (新規 JSX を挿す以上、親の関数実行が必須)。ただし既存要素は `memo` により再描画されず、新規/変更分のみ描画される。
+
+## フォーム入力の再描画対策
+
+「頻繁に変化するが親には影響を与えたくない state」(フォームの入力中の値など) は uncontrolled (`useRef`) にする。\
+`value`/`onChange` の controlled state だと、入力のたびにそのコンポーネント自身が再描画される。
+
+## useTransition との比較 (list-02)
+
+list-01 の store 構造を流用し、大量要素 (数百件) + 人工的な busy-wait で意図的に重くしたリストで `useTransition` の効果を検証する。\
+`addItem` を `startTransition` でラップした版・していない版を Story で切り替え、リストと無関係な `TypingProbe` (独立 input) への入力のカクつきで体感差を確認する。
+
+- `useTransition` は再描画を無くすものではなく、優先度を下げるもの。list-01 の対策 (再描画自体をゼロにする) とは性質が異なる。
+- `memo` でラップした子要素は、`addItem` (構造変更) 時も新規追加分しか再描画されない。「入れ物」側の busy-wait でしか大量要素の再計算コストを再現できない点に注意 (`list-02/_lib/busy-wait.ts` の配置箇所を参照)。
+
+## Highlight updates は信用しすぎない
+
+React DevTools の "Highlight updates when components render" は、実際のコンポーネント関数実行より粒度が粗い。\
+`React.memo` でバイルアウトする場合でも Fiber の reconciliation 処理自体は発生することがあり、DevTools がそれを拾って highlight することがある。
+
+再描画有無の確実な判定は `console.log` をコンポーネント本体の先頭に置く (関数が実際に実行されれば必ず出力される) か、Profiler タブの実測を使う。

--- a/src/prototypes/list-rendering/list-01/_components/add-item-form/index.tsx
+++ b/src/prototypes/list-rendering/list-01/_components/add-item-form/index.tsx
@@ -1,0 +1,52 @@
+import { nanoid } from 'nanoid'
+import { FormEvent, useRef } from 'react'
+
+import { useListStore } from '../../_contexts/list-store-context'
+
+/**
+ * 行追加フォーム
+ *
+ * - input を uncontrolled (ref) で管理する。value/onChange による
+ *   controlled state を持たないため、タイピングのたびに
+ *   AddItemForm 自体が再レンダリングされることがない
+ * - submit 時のみ ref から値を読み、store.addItem を呼ぶ
+ */
+export const AddItemForm = () => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const addItem = useListStore((state) => state.addItem)
+
+  console.log('render: AddItemForm')
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const name = inputRef.current?.value ?? ''
+
+    if (!name) {
+      return
+    }
+
+    addItem({ id: nanoid(), name })
+
+    if (inputRef.current) {
+      inputRef.current.value = ''
+    }
+  }
+
+  return (
+    <form className="flex gap-2 p-2" onSubmit={handleSubmit}>
+      <input
+        className="border border-solid border-gray-300 px-2 py-1"
+        placeholder="新しい名前"
+        ref={inputRef}
+      />
+      <button
+        className="border border-solid border-gray-300 px-2 py-1"
+        type="submit"
+      >
+        追加
+      </button>
+    </form>
+  )
+}

--- a/src/prototypes/list-rendering/list-01/_components/list-item/index.tsx
+++ b/src/prototypes/list-rendering/list-01/_components/list-item/index.tsx
@@ -1,0 +1,38 @@
+import { memo } from 'react'
+
+import { useListStore } from '../../_contexts/list-store-context'
+
+type ListItemProps = {
+  id: string
+}
+
+/**
+ * リストの1要素
+ *
+ * - props で受け取るのは id のみ (不変)。実体は store から直接購読する
+ * - 名前変更時、変更対象の id の selector 結果のみが新しい参照になるため、
+ *   この要素のみ再レンダリングされる
+ */
+export const ListItem = memo((props: ListItemProps) => {
+  const { id } = props
+
+  const item = useListStore((state) => state.byId[id])
+  const renameItem = useListStore((state) => state.renameItem)
+
+  console.log(`render: ListItem ${id}`)
+
+  return (
+    <li className="flex items-center gap-2 border-b border-solid border-gray-200 p-2">
+      <span className="w-16 text-gray-400">{item.id}</span>
+      <input
+        className="border border-solid border-gray-300 px-2 py-1"
+        onChange={(event) => {
+          renameItem(item.id, event.target.value)
+        }}
+        value={item.name}
+      />
+    </li>
+  )
+})
+
+ListItem.displayName = 'ListItem'

--- a/src/prototypes/list-rendering/list-01/_contexts/list-store-context.tsx
+++ b/src/prototypes/list-rendering/list-01/_contexts/list-store-context.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react'
+import { useStore } from 'zustand'
+
+import { ListState, ListStore } from '../_stores/list-store'
+
+/**
+ * store インスタンス (参照は不変) のみを配布する
+ * - value に state 自体を含めないため、renameItem による state 変更では
+ *   Context 自体は再生成されず、Provider 配下の再レンダリングは発生しない
+ */
+export const ListStoreContext = createContext<ListStore | null>(null)
+
+export const useListStore = <T,>(selector: (state: ListState) => T): T => {
+  const store = useContext(ListStoreContext)
+
+  if (store === null) {
+    throw new Error(
+      'useListStore should be used within <ListStoreContext.Provider>',
+    )
+  }
+
+  return useStore(store, selector)
+}

--- a/src/prototypes/list-rendering/list-01/_stores/list-store.ts
+++ b/src/prototypes/list-rendering/list-01/_stores/list-store.ts
@@ -1,0 +1,48 @@
+import { createStore, StoreApi } from 'zustand/vanilla'
+
+export type ListItemData = {
+  id: string
+  name: string
+}
+
+export type ListState = {
+  addItem: (item: ListItemData) => void
+  byId: Record<string, ListItemData>
+  ids: string[]
+  renameItem: (id: string, name: string) => void
+}
+
+export type ListStore = StoreApi<ListState>
+
+/**
+ * List01 インスタンスごとに独立した store を生成する
+ *
+ * - ids (リスト構造) と byId (各要素の実体) を分離して保持する
+ * - renameItem は byId のみ更新するため ids の参照は変わらない
+ *   → ids を購読する List01 (入れ物) は名前変更で再レンダリングされない
+ * - addItem は ids を新しい配列に置き換えるため、追加時のみ
+ *   ids を購読するコンポーネントが再レンダリングされる (これは避けられない)
+ */
+export const createListStore = (initialItems: ListItemData[]): ListStore => {
+  const byId = Object.fromEntries(initialItems.map((item) => [item.id, item]))
+  const ids = initialItems.map((item) => item.id)
+
+  return createStore<ListState>((set) => ({
+    addItem: (item) => {
+      set((state) => ({
+        byId: { ...state.byId, [item.id]: item },
+        ids: [...state.ids, item.id],
+      }))
+    },
+    byId,
+    ids,
+    renameItem: (id, name) => {
+      set((state) => ({
+        byId: {
+          ...state.byId,
+          [id]: { ...state.byId[id], name },
+        },
+      }))
+    },
+  }))
+}

--- a/src/prototypes/list-rendering/list-01/index.stories.tsx
+++ b/src/prototypes/list-rendering/list-01/index.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { List01 as StoryComponent } from '.'
+
+const meta: Meta<typeof StoryComponent> = {
+  component: StoryComponent,
+}
+
+export default meta
+type Story = StoryObj<typeof StoryComponent>
+
+export const Primary: Story = {
+  args: {
+    items: [
+      { id: 'item-1', name: 'アリス' },
+      { id: 'item-2', name: 'ボブ' },
+      { id: 'item-3', name: 'キャロル' },
+    ],
+  },
+}

--- a/src/prototypes/list-rendering/list-01/index.tsx
+++ b/src/prototypes/list-rendering/list-01/index.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { useStore } from 'zustand'
+
+import { AddItemForm } from './_components/add-item-form'
+import { ListItem } from './_components/list-item'
+import { ListStoreContext } from './_contexts/list-store-context'
+import { createListStore, ListItemData } from './_stores/list-store'
+
+type List01Props = {
+  /** 初期リスト */
+  items: ListItemData[]
+}
+
+/**
+ * リスト表示
+ *
+ * - 「入れ物」(List01) 自体が state (useState) を持つ設計だと、
+ *   名前変更のたびに入れ物自体も再レンダリングされてしまう
+ * - state を zustand の vanilla store (Context 経由で配布) に外出しし、
+ *   List01 自体は store を購読しないことで再レンダリングを抑止する
+ * - store は List01 インスタンスごとに1つだけ生成 (useState の遅延初期化)
+ * - List01 は ids のみ購読する。renameItem は ids を変えないため
+ *   名前変更では再レンダリングされない。addItem は ids を変えるため
+ *   行追加時のみ再レンダリングされる (これは避けられない)
+ */
+export const List01 = (props: List01Props) => {
+  const { items } = props
+
+  const [store] = useState(() => createListStore(items))
+
+  const ids = useStore(store, (state) => state.ids)
+
+  console.log('render: List01')
+
+  return (
+    <ListStoreContext.Provider value={store}>
+      <ul className="ui-container w-80">
+        {ids.map((id) => (
+          <ListItem id={id} key={id} />
+        ))}
+      </ul>
+      <AddItemForm />
+    </ListStoreContext.Provider>
+  )
+}

--- a/src/prototypes/list-rendering/list-02/_components/add-item-form/index.tsx
+++ b/src/prototypes/list-rendering/list-02/_components/add-item-form/index.tsx
@@ -1,0 +1,69 @@
+import { nanoid } from 'nanoid'
+import { FormEvent, useRef, useTransition } from 'react'
+
+import { useListStore } from '../../_contexts/list-store-context'
+
+type AddItemFormProps = {
+  /** true の場合 addItem の実行を startTransition でラップする */
+  useTransitionEnabled: boolean
+}
+
+/**
+ * 行追加フォーム
+ *
+ * - input は list-01 同様 uncontrolled (ref)、タイピング自体の再描画は常にゼロ
+ * - useTransitionEnabled が true の場合、addItem (= 大量要素の再レンダリングを
+ *   引き起こす更新) を startTransition で低優先度にする。isPending 中は
+ *   ボタンの表記で進行中であることを示す
+ * - false の場合は同期的に addItem を実行し、大量要素の再レンダリングが
+ *   完了するまでメインスレッドをブロックする (比較対象)
+ */
+export const AddItemForm = (props: AddItemFormProps) => {
+  const { useTransitionEnabled } = props
+
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const addItem = useListStore((state) => state.addItem)
+
+  const [isPending, startTransition] = useTransition()
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const name = inputRef.current?.value ?? ''
+
+    if (!name) {
+      return
+    }
+
+    const item = { id: nanoid(), name }
+
+    if (useTransitionEnabled) {
+      startTransition(() => {
+        addItem(item)
+      })
+    } else {
+      addItem(item)
+    }
+
+    if (inputRef.current) {
+      inputRef.current.value = ''
+    }
+  }
+
+  return (
+    <form className="flex gap-2 p-2" onSubmit={handleSubmit}>
+      <input
+        className="border border-solid border-gray-300 px-2 py-1"
+        placeholder="新しい名前"
+        ref={inputRef}
+      />
+      <button
+        className="border border-solid border-gray-300 px-2 py-1"
+        type="submit"
+      >
+        {isPending ? '追加中...' : '追加'}
+      </button>
+    </form>
+  )
+}

--- a/src/prototypes/list-rendering/list-02/_components/list-item/index.tsx
+++ b/src/prototypes/list-rendering/list-02/_components/list-item/index.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react'
+
+import { useListStore } from '../../_contexts/list-store-context'
+import { busyWait } from '../../_lib/busy-wait'
+
+type ListItemProps = {
+  id: string
+}
+
+/**
+ * リストの1要素 (list-01 と同構造 + 人工的な重さ)
+ *
+ * - memo により、addItem 時は新規追加分のみこの busyWait が実行される。
+ *   既存要素の busyWait コスト (= 大量要素の再計算コスト) を体感したい場合は
+ *   List02 (親) 側の busyWait を見ること
+ */
+export const ListItem = memo((props: ListItemProps) => {
+  const { id } = props
+
+  const item = useListStore((state) => state.byId[id])
+  const renameItem = useListStore((state) => state.renameItem)
+
+  busyWait(0.3)
+
+  return (
+    <li className="flex items-center gap-2 border-b border-solid border-gray-200 p-2">
+      <span className="w-16 text-gray-400">{item.id}</span>
+      <input
+        className="border border-solid border-gray-300 px-2 py-1"
+        onChange={(event) => {
+          renameItem(item.id, event.target.value)
+        }}
+        value={item.name}
+      />
+    </li>
+  )
+})
+
+ListItem.displayName = 'ListItem'

--- a/src/prototypes/list-rendering/list-02/_components/typing-probe/index.tsx
+++ b/src/prototypes/list-rendering/list-02/_components/typing-probe/index.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+
+/**
+ * 体感確認用の独立 input
+ *
+ * - リストの state / store とは完全に無関係
+ * - 大量リスト更新中にこの input への入力がカクつくかどうかで、
+ *   useTransition の効果 (メインスレッドのブロック有無) を体感する
+ */
+export const TypingProbe = () => {
+  const [text, setText] = useState('')
+
+  return (
+    <div className="border-b border-solid border-gray-300 p-2">
+      <label
+        className="mb-1 block text-sm text-gray-500"
+        htmlFor="typing-probe"
+      >
+        体感確認用 (リストと無関係、行追加中にここへ入力してカクつきを見る)
+      </label>
+      <input
+        className="w-full border border-solid border-gray-300 px-2 py-1"
+        id="typing-probe"
+        onChange={(event) => {
+          setText(event.target.value)
+        }}
+        placeholder="ここに入力しながら「追加」を押す"
+        value={text}
+      />
+    </div>
+  )
+}

--- a/src/prototypes/list-rendering/list-02/_contexts/list-store-context.tsx
+++ b/src/prototypes/list-rendering/list-02/_contexts/list-store-context.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react'
+import { useStore } from 'zustand'
+
+import { ListState, ListStore } from '../_stores/list-store'
+
+/**
+ * store インスタンス (参照は不変) のみを配布する
+ * - value に state 自体を含めないため、renameItem による state 変更では
+ *   Context 自体は再生成されず、Provider 配下の再レンダリングは発生しない
+ */
+export const ListStoreContext = createContext<ListStore | null>(null)
+
+export const useListStore = <T,>(selector: (state: ListState) => T): T => {
+  const store = useContext(ListStoreContext)
+
+  if (store === null) {
+    throw new Error(
+      'useListStore should be used within <ListStoreContext.Provider>',
+    )
+  }
+
+  return useStore(store, selector)
+}

--- a/src/prototypes/list-rendering/list-02/_lib/busy-wait.ts
+++ b/src/prototypes/list-rendering/list-02/_lib/busy-wait.ts
@@ -1,0 +1,10 @@
+/**
+ * 意図的にメインスレッドを ms 分だけ同期的にブロックする
+ * - useTransition の効果を体感できるようにするための人工的な重さ
+ */
+export const busyWait = (ms: number) => {
+  const start = performance.now()
+  while (performance.now() - start < ms) {
+    // 意図的な busy wait
+  }
+}

--- a/src/prototypes/list-rendering/list-02/_stores/list-store.ts
+++ b/src/prototypes/list-rendering/list-02/_stores/list-store.ts
@@ -1,0 +1,49 @@
+import { createStore, StoreApi } from 'zustand/vanilla'
+
+export type ListItemData = {
+  id: string
+  name: string
+}
+
+export type ListState = {
+  addItem: (item: ListItemData) => void
+  byId: Record<string, ListItemData>
+  ids: string[]
+  renameItem: (id: string, name: string) => void
+}
+
+export type ListStore = StoreApi<ListState>
+
+/**
+ * List02 インスタンスごとに独立した store を生成する
+ *
+ * - ids (リスト構造) と byId (各要素の実体) を分離して保持する
+ * - renameItem は byId のみ更新するため ids の参照は変わらない
+ *   → ids を購読する List02 (入れ物) は名前変更で再レンダリングされない
+ * (list-01 と同構造、useTransition 検証用に複製)
+ * - addItem は ids を新しい配列に置き換えるため、追加時のみ
+ *   ids を購読するコンポーネントが再レンダリングされる (これは避けられない)
+ */
+export const createListStore = (initialItems: ListItemData[]): ListStore => {
+  const byId = Object.fromEntries(initialItems.map((item) => [item.id, item]))
+  const ids = initialItems.map((item) => item.id)
+
+  return createStore<ListState>((set) => ({
+    addItem: (item) => {
+      set((state) => ({
+        byId: { ...state.byId, [item.id]: item },
+        ids: [...state.ids, item.id],
+      }))
+    },
+    byId,
+    ids,
+    renameItem: (id, name) => {
+      set((state) => ({
+        byId: {
+          ...state.byId,
+          [id]: { ...state.byId[id], name },
+        },
+      }))
+    },
+  }))
+}

--- a/src/prototypes/list-rendering/list-02/index.stories.tsx
+++ b/src/prototypes/list-rendering/list-02/index.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { List02 as StoryComponent } from '.'
+
+const meta: Meta<typeof StoryComponent> = {
+  component: StoryComponent,
+}
+
+export default meta
+type Story = StoryObj<typeof StoryComponent>
+
+const items = Array.from({ length: 500 }).map((_, index) => ({
+  id: `item-${index}`,
+  name: `名前-${index}`,
+}))
+
+export const WithoutTransition: Story = {
+  args: {
+    items,
+    useTransitionEnabled: false,
+  },
+}
+
+export const WithTransition: Story = {
+  args: {
+    items,
+    useTransitionEnabled: true,
+  },
+}

--- a/src/prototypes/list-rendering/list-02/index.tsx
+++ b/src/prototypes/list-rendering/list-02/index.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { useStore } from 'zustand'
+
+import { AddItemForm } from './_components/add-item-form'
+import { ListItem } from './_components/list-item'
+import { TypingProbe } from './_components/typing-probe'
+import { ListStoreContext } from './_contexts/list-store-context'
+import { busyWait } from './_lib/busy-wait'
+import { createListStore, ListItemData } from './_stores/list-store'
+
+type List02Props = {
+  /** 初期リスト (大量要素で useTransition の効果を体感する想定) */
+  items: ListItemData[]
+  /** true の場合 addItem を startTransition でラップする */
+  useTransitionEnabled: boolean
+}
+
+/**
+ * list-01 + useTransition 比較検証
+ *
+ * - list-01 と同じ ids/byId 分離 store を使用
+ * - ids が変わるたび (= addItem 実行時) に、リスト全体の再計算コストを模した
+ *   busy-wait を List02 (入れ物) 側で実行する。ListItem 個別の busy-wait は
+ *   memo により新規追加分にしか効かないため、addItem のコストを体感するには
+ *   ここで要素数分の重さを持たせる必要がある
+ * - TypingProbe (リストと無関係な input) への入力のカクつきで、
+ *   useTransitionEnabled の有無による体感差を確認する
+ */
+export const List02 = (props: List02Props) => {
+  const { items, useTransitionEnabled } = props
+
+  const [store] = useState(() => createListStore(items))
+
+  const ids = useStore(store, (state) => state.ids)
+
+  busyWait(ids.length * 0.3)
+
+  return (
+    <ListStoreContext.Provider value={store}>
+      <TypingProbe />
+      <ul className="ui-container w-80">
+        {ids.map((id) => (
+          <ListItem id={id} key={id} />
+        ))}
+      </ul>
+      <AddItemForm useTransitionEnabled={useTransitionEnabled} />
+    </ListStoreContext.Provider>
+  )
+}


### PR DESCRIPTION
# #48 prototypes/list-rendering

リストの再描画最適化の検証を追加。

## 対応

- [x] list-01: zustand vanilla store + Context で「入れ物」コンポーネントの再描画を抑止 (normalized state: ids/byId 分離)
- [x] list-02: 大量要素における useTransition 効果の検証 (busy-wait による人工的な重さ、TypingProbe での体感比較)

## 補足

- stage-04 (#35) の「操作のたびに stage 全体が再レンダリングされている」課題への proof-of-concept として着手
- 検証詳細: `.claude/.steering/20260712-list-rerender-optimization/design.md`
- 今後 #35 の作業をこのブランチへ rebase する予定