### PR TITLE
#50 prototypes/time-control-01

### DIFF
--- a/src/prototypes/time-control/time-control-01/README.md
+++ b/src/prototypes/time-control/time-control-01/README.md
@@ -1,0 +1,23 @@
+# TimeControl01
+
+focus/blur/mousedown/mouseup の生イベントから click/drop を判定する状態機械のプロトタイプ。
+
+## 状態遷移
+
+`idle` → (mousedown) → `pressed` → (focusout) → `pressed-blurred` → (focus) → `pressed`
+
+- `pressed` で mouseup → **click** 判定、`idle` に戻る
+- `pressed-blurred` で mouseup → **drop** 判定、`idle` に戻る
+
+focusout (フォーカス離脱) を「ポインタが元の要素から離れた」ことの代理指標として使う。
+
+## スコープ外
+
+ドラッグ中の座標追跡・表示は対象外。click/drop の確定のみ扱う。
+
+## 構成
+
+- `types.ts` — 型定義
+- `reduce-pointer-state.ts` — 純粋な遷移関数
+- `_hooks/use-pointer-state.ts` — 遷移結果 (`transition`) とイベント履歴 (`eventLog`) を保持する hook
+- `index.tsx` — デモ用コンポーネント

--- a/src/prototypes/time-control/time-control-01/__tests__/reduce-pointer-state.test.ts
+++ b/src/prototypes/time-control/time-control-01/__tests__/reduce-pointer-state.test.ts
@@ -1,0 +1,45 @@
+import { reducePointerState } from '../reduce-pointer-state'
+
+test('idle 状態で mousedown すると pressed に遷移する', () => {
+  expect(reducePointerState('idle', 'mousedown')).toEqual({
+    nextState: 'pressed',
+  })
+})
+
+test('pressed 状態で mouseup すると click 判定で idle に戻る', () => {
+  expect(reducePointerState('pressed', 'mouseup')).toEqual({
+    nextState: 'idle',
+    resolved: 'click',
+  })
+})
+
+test('pressed 状態で focusout すると pressed-blurred に遷移する', () => {
+  expect(reducePointerState('pressed', 'focusout')).toEqual({
+    nextState: 'pressed-blurred',
+  })
+})
+
+test('pressed-blurred 状態で mouseup すると drop 判定で idle に戻る', () => {
+  expect(reducePointerState('pressed-blurred', 'mouseup')).toEqual({
+    nextState: 'idle',
+    resolved: 'drop',
+  })
+})
+
+test('pressed-blurred 状態で focus すると pressed に戻る', () => {
+  expect(reducePointerState('pressed-blurred', 'focus')).toEqual({
+    nextState: 'pressed',
+  })
+})
+
+test.each([
+  ['idle', 'mouseup'],
+  ['idle', 'focus'],
+  ['idle', 'focusout'],
+  ['pressed', 'mousedown'],
+  ['pressed', 'focus'],
+  ['pressed-blurred', 'mousedown'],
+  ['pressed-blurred', 'focusout'],
+] as const)('%s 状態で %s は no-op (状態維持)', (state, event) => {
+  expect(reducePointerState(state, event)).toEqual({ nextState: state })
+})

--- a/src/prototypes/time-control/time-control-01/_hooks/use-pointer-state.ts
+++ b/src/prototypes/time-control/time-control-01/_hooks/use-pointer-state.ts
@@ -1,0 +1,42 @@
+import { useReducer } from 'react'
+
+import { reducePointerState } from '../reduce-pointer-state'
+import { EventLog, PointerRawEventType, PointerTransition } from '../types'
+
+type PointerStateWithLog = {
+  eventLog: EventLog<PointerRawEventType>
+  transition: PointerTransition
+}
+
+const initialState: PointerStateWithLog = {
+  eventLog: [],
+  transition: { nextState: 'idle' },
+}
+
+const reducer = (
+  state: PointerStateWithLog,
+  event: PointerRawEventType,
+): PointerStateWithLog => ({
+  eventLog: [...state.eventLog, { event, time: Date.now() }],
+  transition: reducePointerState(state.transition.nextState, event),
+})
+
+/**
+ * PointerState を管理する hook
+ *
+ * - click/drop 判定結果は transition.resolved に都度反映される (dispatch 毎に新規オブジェクト)
+ * - 呼び出し側で transition.resolved を監視し、必要な副作用 (drop 処理など) を実行する
+ * - eventLog は受け取った生イベントの時系列記録 (破棄しない持ち越し型)
+ */
+export const usePointerState = (): {
+  /** 生イベントを流し込む */
+  dispatch: (event: PointerRawEventType) => void
+  /** 受け取った生イベントの時系列記録 */
+  eventLog: EventLog<PointerRawEventType>
+  /** 現在の状態と直近の判定結果 */
+  transition: PointerTransition
+} => {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  return { dispatch, eventLog: state.eventLog, transition: state.transition }
+}

--- a/src/prototypes/time-control/time-control-01/index.stories.tsx
+++ b/src/prototypes/time-control/time-control-01/index.stories.tsx
@@ -1,0 +1,12 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { TimeControl01 as StoryComponent } from '.'
+
+const meta: Meta<typeof StoryComponent> = {
+  component: StoryComponent,
+}
+
+export default meta
+type Story = StoryObj<typeof StoryComponent>
+
+export const Primary: Story = {}

--- a/src/prototypes/time-control/time-control-01/index.tsx
+++ b/src/prototypes/time-control/time-control-01/index.tsx
@@ -1,0 +1,42 @@
+import { useCallback } from 'react'
+
+import { usePointerState } from './_hooks/use-pointer-state'
+import { PointerRawEventType } from './types'
+
+/**
+ * PointerState 遷移のデモ
+ *
+ * - 単一要素の focus/blur/mousedown/mouseup を usePointerState に流し込み、\
+ *   click/drop 判定結果を表示する
+ */
+export const TimeControl01 = () => {
+  const { dispatch, eventLog, transition } = usePointerState()
+
+  const handle = useCallback(
+    (event: PointerRawEventType) => () => dispatch(event),
+    [dispatch],
+  )
+
+  return (
+    <div className="ui-container">
+      <button
+        onBlur={handle('focusout')}
+        onFocus={handle('focus')}
+        onMouseDown={handle('mousedown')}
+        onMouseUp={handle('mouseup')}
+        type="button"
+      >
+        pointer target
+      </button>
+      <p>state: {transition.nextState}</p>
+      <p>resolved: {transition.resolved ?? '-'}</p>
+      <ul>
+        {eventLog.map((entry, index) => (
+          <li key={index}>
+            {new Date(entry.time).toLocaleTimeString()} {entry.event}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/prototypes/time-control/time-control-01/reduce-pointer-state.ts
+++ b/src/prototypes/time-control/time-control-01/reduce-pointer-state.ts
@@ -1,0 +1,44 @@
+import { PointerRawEventType, PointerState, PointerTransition } from './types'
+
+const noop = (state: PointerState): PointerTransition => ({ nextState: state })
+
+/**
+ * click/drop 判定の遷移表
+ *
+ * - focusout を経ない mouseup は click、経た mouseup は drop と判定する
+ * - focusout は「ポインタが元の要素から離れた」ことの代理指標として使う
+ */
+const transitions: Record<
+  PointerState,
+  Record<PointerRawEventType, (state: PointerState) => PointerTransition>
+> = {
+  idle: {
+    focus: noop,
+    focusout: noop,
+    mousedown: () => ({ nextState: 'pressed' }),
+    mouseup: noop,
+  },
+  pressed: {
+    focus: noop,
+    focusout: () => ({ nextState: 'pressed-blurred' }),
+    mousedown: noop,
+    mouseup: () => ({ nextState: 'idle', resolved: 'click' }),
+  },
+  'pressed-blurred': {
+    focus: () => ({ nextState: 'pressed' }),
+    focusout: noop,
+    mousedown: noop,
+    mouseup: () => ({ nextState: 'idle', resolved: 'drop' }),
+  },
+}
+
+/**
+ * 状態遷移を1ステップ進める
+ *
+ * @param state 現在の状態
+ * @param event 受信した生イベント
+ */
+export const reducePointerState = (
+  state: PointerState,
+  event: PointerRawEventType,
+): PointerTransition => transitions[state][event](state)

--- a/src/prototypes/time-control/time-control-01/types.ts
+++ b/src/prototypes/time-control/time-control-01/types.ts
@@ -1,0 +1,51 @@
+/**
+ * 時間管理の基本単位
+ *
+ * - 時刻付きイベントログの1エントリ
+ */
+export type TimeEvent<TEvent> = {
+  /** イベント本体 */
+  event: TEvent
+  /** イベント発生時刻 (epoch ms) */
+  time: number
+}
+
+/**
+ * 時刻付きイベントログ本体
+ *
+ * - 持ち越し型 (処理後も破棄しない)
+ */
+export type EventLog<TEvent> = TimeEvent<TEvent>[]
+
+/** drag/click/drop 判定に使う生イベント種別 */
+export type PointerRawEventType = 'focus' | 'focusout' | 'mousedown' | 'mouseup'
+
+/** 生イベント (対象要素の識別子を伴う) */
+export type PointerRawEvent = {
+  /** 発生元要素の識別子 */
+  targetId: string
+  /** 生イベント種別 */
+  type: PointerRawEventType
+}
+
+/** drag/click/drop 判定の状態 */
+export type PointerState = 'idle' | 'pressed-blurred' | 'pressed'
+
+/**
+ * 確定した判定結果
+ *
+ * - ドラッグ中の追跡は対象外、click/drop の確定のみ扱う
+ */
+export type PointerResolution = 'click' | 'drop'
+
+/**
+ * 状態遷移の結果
+ *
+ * - resolved は click/drop 確定時のみ付与
+ */
+export type PointerTransition = {
+  /** 遷移後の状態 */
+  nextState: PointerState
+  /** 確定した判定結果。未確定なら undefined */
+  resolved?: PointerResolution
+}


### PR DESCRIPTION
## Summary

- focus/blur/mousedown/mouseup の生イベントから click/drop を判定する PointerState 状態機械のプロトタイプ (time-control-01) を追加
- 型定義 → 遷移ロジック → テスト → hook → デモコンポーネント → README の順で実装

## Test plan

- [x] `yarn check-types` (型エラーなし)
- [x] `yarn lint` (lint クリーン)
- [x] `NEXT_PUBLIC_API_URL=http://localhost:3000 yarn test run src/prototypes/time-control` (12件全通過)
- [x] Storybook + Playwright ヘッドレス Chromium で click/drop 判定を実動作確認

Closes #50