### PR TITLE
time-control-02: Intent/Execution 分離プロトタイプ追加

### DIFF
--- a/.claude/.steering/20260727-time-control-02-next-steps/design.md
+++ b/.claude/.steering/20260727-time-control-02-next-steps/design.md
@@ -1,0 +1,223 @@
+# time-control-02 今後の検討事項 (方向 / Collision / Custom Event 疎結合化)
+
+## 目的
+
+`src/prototypes/time-control/time-control-02/` (issue #50) の延長として、以下3件を実装前に検討・計画する。
+
+1. 方向 (Direction) の概念と英訳候補
+2. 移動先衝突 (Collision) の概念と管理 store
+3. Custom Event 経由でのドメイン間疎結合化 (アーキテクチャ全体方針)
+
+いずれもまだ実装しない。方針・候補の洗い出しと決定事項の記録が目的。
+
+## 背景・制約
+
+- `docs/concept/ideas/action-phase.md` に 企図(Intent)→予備→実行→成否→事後(Resolution) の5段階モデルと、所要時間 (`ActionTiming`)・割込み (`interruptibleUntil`)・interrupt/intercept の区別が定義済み (未実装、概念のみ)。
+- 座標は自由 `{ x, y }`、初期値 `{ x: 0, y: 0 }`、クランプなし (time-control-02 の既定方針)。
+- 経路探索・境界処理は time-control-02 のスコープ外 (stage-04 と同じ限定)。
+- **下記「実装済み: Intent/Execution 分離システム」節が現状の実装の正確な状態を示す (2026-07-30 時点)。この節より上の「背景・制約」旧記述は古いスナップショットなので参照しないこと。**
+
+## 実装済み: Intent/Execution 分離システム (2026-07-30)
+
+Direction/Collision/CustomEvent (下記の実装計画1〜3) とは別に、issue #50 の中で並行して大きく実装が進んだ。move (旧 aim) ボタンの即時移動を廃止し、企図→経路生成→tick刻み実行→履歴の一連のシステムを構築済み。**次回セッションはこの節を読めば実装状況を再構築できる。**
+
+### ファイル構成
+
+```
+src/prototypes/time-control/time-control-02/
+  types.ts                          # ActorId/Position/ActionPhase/MoveIntent/PathStep/MovePath/
+                                     # ProgressMode/ScheduleRow/HistoryRow/ActionLogEntry/TimeEvent/EventLog
+  _stores/actor-store.ts            # 本体 (zustand vanilla)。下記「store の状態」参照
+  _contexts/actor-store-context.tsx # Context + useActorStore(selector)
+  _lib/
+    generate-move-path.ts           # 経路生成 (純粋関数)
+    get-tick-ms.ts                  # BASE_TICK_MS / tickRate → tickMs
+    build-schedule.ts               # 予定プレビュー用: 経路+tickCount+tickRate → ScheduleRow[] (時刻マージ)
+    build-history.ts                # 履歴用: actionLog → HistoryRow[] (gameTimeMs マージ)
+    stage-coords.ts                 # STAGE_SIZE/STAGE_CENTER/STAGE_SCALE + Position→CSS px 変換
+  _components/
+    action-bar/          # 全actor一括: 行動決定・mode(auto/manual)トグル・reset
+    actor-item/           # actor毎の行: position/path数/target/eta/minPathSteps入力/set targetボタン
+    stage-view/            # CSS絶対配置の舞台 (300x300px, bg-gray-50)
+    actor-marker/           # actor毎: 現在位置(円+ラベル)・残り経路(灰点)・移動軌跡(薄青点、actionLog由来で消えない)
+    schedule-preview/        # 「予定」テーブル: 経過時間列 + actor列(●印)
+    action-log-panel/         # 「履歴」テーブル: 経過時間列 + actor列(phase+座標)
+  __tests__/  (29件全通過)
+  README.md
+```
+
+`index.tsx` レイアウト: ActionBar → [StageView | actor一覧ul] (flex横並び) → [予定 | 履歴] (flex横並び)。
+
+### 移動フロー
+
+1. **set target** (actor毎ボタン, `dispatchMoveIntent`): position は変えない。`generateMovePath(from, target, stepDistance, minSteps)` で経路生成、`movePathById` に格納。actionLog に `phase:'intent'` を1件追加。
+2. **行動決定** (全actor一括, `ActionBar`): 各actorの `dispatchAction` をループ呼び出し。`progressModeById` に応じて:
+   - `manual`: 1呼び出しで経路の先頭1 tick分だけ進む
+   - `auto`: 呼び出し後、actor毎の `tickMs` 間隔で内部 `setTimeout` ループが経路を最後まで自動消化
+   - 各tick: `actionLog` に `phase:'execution'`(途中)または`'resolution'`(最終) を追加、`positionById`/`movePathById` 更新
+3. **mode** (全actor一括): auto/manual切替、`行動決定`の挙動を変える
+
+### store の状態 (`ActorState`)
+
+`actionLog` / `dispatchAction` / `dispatchMoveIntent` / `minPathStepsById` / `movePathById` / `positionById` / `progressModeById` / `reset` / `setMinPathSteps` / `setProgressMode` / `speedById` / `tickCountById` / `tickRateById`
+
+- `speedById` (距離/ms, `DEFAULT_SPEED=0.01`) と `tickRateById` (`DEFAULT_TICK_RATE=2`) は別役割。`tickMs = getTickMs(tickRate) = BASE_TICK_MS(400) / tickRate`、`stepDistance = speed * tickMs`。
+- `tickRateById` は内部実装専用の名前。画面表示用の「敏捷性 (agility)」は別概念として将来追加予定、変換式は未定 (ユーザー指示: 現在の実装にそのまま `agility` を使わず別名にしておきたい、という理由)。
+- `tickCountById`: actor毎の**累積**tickカウンタ。企図のたびにリセットしない (重要、後述バグ参照)。
+- `minPathStepsById` (`DEFAULT_MIN_PATH_STEPS=1`): 経路の最低step数。actor-item に数値inputで表示・編集可能。
+
+### 経路生成ロジック (`generateMovePath`)
+
+最終形: 最終step以外は必ず `stepDistance` いっぱい移動する (actorの移動可能距離を使い切る)。最終stepのみ端数を吸収してtargetに一致 (目的地前の減速・最終調整)。`minSteps` は距離が短すぎて `stepDistance` 基準のstep数がそれを下回る場合のみ、例外的に均等分割にフォールバックする。
+
+### 修正済みバグ2件 (重要、再発させないこと)
+
+1. **gameTimeMs衝突バグ**: 当初 `gameTimeMs` は企図ごとにリセットする相対値だった (`pathLengthById` 由来)。2回目以降の「行動決定」が1回目と同じ `gameTimeMs` を生成し、`buildHistory` が同一値でマージする際に旧entryを上書き→履歴が消えたように見えた。修正: `pathLengthById` を `tickCountById` (累積・非リセット) に置き換え、`gameTimeMs = tickCount * tickMs` を絶対ゲームクロックにした。`buildSchedule` も `tickCountById` を起点にし、予定と履歴の時間軸を連続させている。
+2. **経路の不均等距離バグ**: 上記「経路生成ロジック」参照。旧実装は総距離を `stepCount` で均等割りしており、中間stepが `stepDistance` を使い切っていなかった。
+
+### 画面の見た目調整の経緯 (今後同種の要望が来たら参照)
+
+- 背景/ラベル: `StageView` に `bg-gray-50`、`ActorMarker` ラベルは `id.split('-').pop()` で短縮 (`actor-a`→`a`) + `font-bold`。長い文字列を小さい円に入れると白文字が白背景にはみ出て見えなくなる問題があった。
+- `ActorItem` の `<li>` は `whitespace-nowrap` 必須、各 `<span>` に `min-w-*` を付けて列幅を揃えている (幅指定なしだとテキストが折り返し、行ごとにボタン位置がずれる)。
+- `min` (最低step数) input は **バリデーションで onChange を条件付きにしてはいけない**。controlled input で無効値の時に `setState` をスキップすると、値が押し戻されて実質入力不能になる (実際に発生したバグ)。下限チェックは使用時 (`dispatchMoveIntent` 内で `Math.max(1, ...)`) に置くこと。
+- `ui/table` の低レベル部品 (`TableElement`/`TableHeader`/`TableBody`/`TableRow`/`TableHead`/`TableCell`) を `SchedulePreview`/`ActionLogPanel` で使用、`table-fixed` で列幅均等化。
+- `ui/button` の `Button` (`@/components/ui/button`) を生 `<button>` の代わりに使用。
+
+### 検証時の注意 (CLAUDE.md にも記載済み)
+
+- Storybook は常駐前提。`curl -sf http://localhost:6006` で起動確認、起動中なら再利用 (再起動しない)。
+- Playwright検証スクリプトは `scratch/verify.mjs` 固定名 (許可リスト肥大化防止、`scratch/`はgitignore対象)。都度上書きする。
+- `#storybook-root` 配下に絞って要素検索すること (絞らないと "No Preview" 等のダミーDOMにヒットする)。
+
+## 実装計画
+
+- [x] 1. Direction 概念・命名の検討 (用語決定、値の表現方式・Position との関係は今後)
+  - [x] 候補比較・採用: `Direction` / `Facing` / `Heading` 併用開始、`Orientation` は必要になり次第追加 (決定事項参照)
+  - [x] 値の表現方式: 角度を採用 (4方向/8方向 enum は不採用、決定事項参照)
+  - [x] 内部表現方式: ハイブリッド採用 (Heading/Facing は独立した別値、決定事項参照)
+  - [x] 角度の単位・基準・回転方向を決定 (ラジアン、y下向き screen 座標系、決定事項参照)
+  - [x] `Position { x, y }` との関係整理: 2点間を極座標 (`distance`/`angleRad`) で算出する共通ユーティリティ方針を採用 (決定事項参照)
+  - [x] 視界 (Field of View) 判定処理の方針を決定: Facing と対象方向の角度差 (正規化後) が閾値以内かで判定 (決定事項参照)
+  - [ ] 視界の距離上限 (見える範囲) の具体値を決定
+  - [ ] action-phase.md の `MoveIntent`/`target` との関係 (target 座標から算出 vs 明示的に dispatch する)
+- [ ] 2. Collision 概念の追加
+  - [x] 体格 (Physique) の概念を採用: 体の大きさを円 (半径) で表現するシンプルなモデル (決定事項参照)
+  - [x] 段階を「回避検討 → 衝突」の2段階とする方針を決定 (決定事項参照)
+  - [ ] 「回避検討」の発生条件 (判定機会) の具体化: action-phase.md のどの段階に対応させるか
+  - [ ] 移動先に既に別 actor が存在する場合の挙動候補を列挙 (移動拒否/入替/スタック許容/押し出し 等)
+  - [ ] 衝突判定・解決を担う専用 store の設計 (`actor-store.ts` の `positionById` から座標→actorId の逆引きが必要になる可能性)
+  - [ ] `dispatchMoveIntent` との関係: 衝突判定は intent 側で行うか、resolution 側で行うか (action-phase.md の PreAction/Outcome との対応も検討)
+- [ ] 3. Custom Event 経由の疎結合化 (アーキテクチャ全体方針)
+  - [ ] `src/hooks/useEventListener.ts` の設計 (useEffect ベース、`window`/`EventTarget` どちらを対象にするか)
+  - [ ] 各 store (actor-store, 将来の collision-store 等) が dispatch 系関数の直接 import ではなく、Custom Event の発行・購読で連携する設計への移行方針
+  - [ ] イベント名・payload の型付け方針 (`CustomEvent<T>` のジェネリクス活用など)
+  - [ ] 移行範囲: プロトタイプ限定ではなく `src/hooks/` への本実装 (共通実装) として位置付け
+
+## 決定事項
+
+### Direction 系用語 (2026-07-27)
+
+`Direction` / `Facing` / `Heading` を併用する。`Orientation` (キャラクターの回転等) は状況に応じて追加、今回は対象外。
+
+| 英語 | 日本語 | 用途 |
+| --- | --- | --- |
+| Direction | (訳語なし、包括語として使用) | シンプルな方向。目的地・目標などに対して使う汎用語 |
+| Facing | 指向 | 移動方向と切り離した「向き」。後退・カニ歩きなど、移動方向と体の向きが一致しないケースを想定。軍事用語 (銃口の指向方向) から採用 |
+| Heading | 針路 | 進行方向そのものを管理 |
+| Orientation | (未定、保留) | キャラクターの回転など。必要になった時点で検討 |
+
+今回 (time-control-02 で) 扱う情報の対象は **Facing (指向)** と **Heading (針路)**。`Direction` は個別の型・値ではなく概念の総称として位置づけ、型定義には直接登場しない想定。
+
+ゆくゆくは `docs/` 配下 (`docs/terminology/` 想定) への切り出しを予定。この steering ファイルはその前段の検討ログ。
+
+### Direction の値表現・位置関係管理 (2026-07-27)
+
+- Facing/Heading の値表現は **角度** を採用する (4方向/8方向の enum 方式は不採用)。
+- 座標 (`Position { x, y }`) は数値のまま扱う (grid 化・整数化はしない、現行方針を維持)。
+- 位置関係の管理は **円を使用したもの** とする。actor 間の相対角度・距離といった位置関係を、円 (単位円・三角関数) ベースで算出する方針。
+  - 例: 2点間の角度は `atan2(dy, dx)` で算出。
+
+### 角度の単位・座標系 (2026-07-27)
+
+- 単位は **ラジアン** を採用 (内部は常にラジアン、度への変換は表示層のみで行う)。理由: `Math.atan2`/`sin`/`cos` がラジアン前提のため、変換コストなしに直結できる。
+- 座標系は **screen 座標系 (y 下向き)** を採用 (`Position` の y は下方向が正、stage-04 等の `top`/`left` ベース DOM 描画と一致させる)。
+- 回転方向の注意点: `Math.atan2`/`sin`/`cos` は数学座標系 (y 上向き) では反時計回り正だが、screen 座標系 (y 下向き) では同じ計算式のまま **見た目は時計回り** になる (x 軸から +y 方向への回転が画面上で下向きに見えるため)。\
+  内部の角度演算はそのまま標準の `Math`API を使い、「画面上は時計回りに見える」点だけ実装・UI表示側で認識しておく (符号反転などの補正は行わない)。
+
+### Heading/Facing の内部表現 (2026-07-27)
+
+Heading と Facing は独立した別値として持つ (一方から他方を導出しない)。
+
+- **Heading**: 内部はベクトル `{ vx, vy }` (移動方向 + 速度を一体で保持)。移動計算は `x += vx * dt` の加算のみで済み、毎フレーム発生しうる更新のコストを抑える。
+- **Facing**: 内部は角度そのもの。Heading とは独立に、明示的な dispatch 等で設定する (後退・カニ歩きのように Heading と一致しないケースを表現するのが目的のため)。
+- `atan2` は Facing の算出元ではなく、「Heading(ベクトル) と Facing(角度) を比較したい」「actor 間の相対角度を求めたい」等、ベクトル⇔角度の変換が必要な場面で都度使う変換ユーティリティとして位置づける。
+
+### Position 間の関係算出 (2026-07-27)
+
+2点間の関係を極座標 (距離 + 角度) として算出する共通ユーティリティを想定する。
+
+```ts
+type PolarRelation = {
+  distance: number // 2点間の距離 (= 円の半径)
+  angleRad: number // atan2(dy, dx) によるラジアン角
+}
+
+const getPolarRelation = (from: Position, to: Position): PolarRelation => {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  return {
+    distance: Math.sqrt(dx * dx + dy * dy),
+    angleRad: Math.atan2(dy, dx),
+  }
+}
+```
+
+- `angleRad` は Facing/Heading との比較 (正面判定・視界判定など) に使う。
+- `distance` は近接判定に使う。座標が自由 (grid でない) ため、「同一座標」判定ではなく「半径内」判定が現実的 → 体格 (Physique) / Collision の下地になる。
+
+### 体格 (Physique) と Collision の段階 (2026-07-27)
+
+- **体格 (Physique)**: 体の大きさを円 (半径のみ) で表現するシンプルなモデル。
+
+  ```ts
+  /** 体格。体の大きさを円で表現する単純なモデル */
+  type Physique = {
+    /** 半径 */
+    radius: number
+  }
+  ```
+
+- **Collision の段階**: 「回避検討」→「衝突」の2段階とする。
+  - 判定の基準は、2 actor 間の `distance` (Position 間の関係算出を利用) と、双方の Physique の半径合計との差分 = マージン (`margin = distance - (radiusA + radiusB)`)。
+  - マージンが 0 になった時点 (体が触れ合う距離まで接近した時点) が「衝突」。
+  - マージンが 0 になるまでの間に判定機会が発生した場合、「回避検討」を実施する (接触前に回避可否を判定する猶予フェーズ)。「判定機会」の具体的な発生条件 (action-phase.md のどの段階に対応させるか) は未確定、残課題。
+
+### 視界 (Field of View) 判定 (2026-07-27)
+
+Facing (指向) を基準に、左右60度 (合計120度) を視界とする。判定は「Facing と対象方向の角度差が閾値以内か」で行う。
+
+```ts
+// -π 〜 π の範囲に正規化する (円環角度の差分計算に必須)
+const normalizeAngle = (angleRad: number): number =>
+  Math.atan2(Math.sin(angleRad), Math.cos(angleRad))
+
+const isWithinFieldOfView = (
+  facingRad: number,
+  from: Position,
+  to: Position,
+  halfFovRad: number, // 左右60度なら Math.PI / 3
+): boolean => {
+  const { angleRad } = getPolarRelation(from, to) // Position 間の関係算出を再利用
+  const diff = normalizeAngle(angleRad - facingRad)
+  return Math.abs(diff) <= halfFovRad
+}
+```
+
+- 角度差は単純な引き算だと円環の境界 (例: Facing=170°, 対象方向=-170° → 素の差 -340°) で破綻するため、`Math.atan2(Math.sin(θ), Math.cos(θ))` で -π〜π の主値に正規化してから比較する。
+- 角度のみの判定であり、実際の「見える範囲」には距離上限も絡む。`getPolarRelation` の `distance` と組み合わせ、「角度内 かつ 距離内」で最終判定する方針 (距離上限の具体値は未確定、残課題)。
+
+## 懸念・リスク
+
+- Custom Event 化は疎結合を得る一方、型安全性・追跡可能性 (どこで発行されどこで購読されるか) が下がるリスクがある。イベント名の一元管理・型定義の方針を先に固める必要がある。
+- Collision store の座標→actorId 逆引きは、actor 数増加時のパフォーマンスにも関わる (normalized state の設計次第)。
+- Direction を独立状態として持つ場合、`dispatchMoveIntent` の度に Direction も更新する必要が生じ、store の責務境界 (position 管理 vs 向き管理) が曖昧にならないよう注意。

--- a/docs/concept/ideas/action-phase.md
+++ b/docs/concept/ideas/action-phase.md
@@ -81,7 +81,40 @@ Gemini 生成
 
 ---
 
-## 4. プログラミング（C# / TypeScriptなど）での実装イメージ
+## 4. 各段階の所要時間と割込み (Interrupt)
+
+各段階は瞬時に遷移するとは限らず、行動ごとに固有の所要時間を持つ。
+
+### 所要時間 (Duration)
+
+- `Intent → PreAction → Execution → Outcome → Resolution` の各遷移は所要時間 (duration) を持つ。
+- 行動ごとに **PreAction** の所要時間が最も大きく変動する (無詠唱の通常攻撃は 0、大技の詠唱は数ターン、既存の「詠唱（チャージ）」記述に対応)。
+- **Outcome**/**Resolution** は判定結果の適用に要する演出時間として扱う。
+
+### 割込み可能段階 (Interruptible Until)
+
+- 行動ごとに「どの段階まで割込み (中断) を受け付けるか」を定義する。この段階を超えると行動は確定し、以降は割込みで止められない。
+  - 例: 通常攻撃は **PreAction** まで割込み可能、**Execution** 以降は確定。
+  - 例: 見切り・カウンター系の技は **Execution** の完了直前まで割込み可能 (相手の動きを見てから割込みを間に合わせる必要がある)。
+- この割込み可能な最終段階を `interruptibleUntil` と呼ぶ。
+
+### 「後の先」の表現
+
+「後の先」(相手の動きを見てから、相手より先に成立させる技) は、割込み側が対象の Intent/PreAction/Execution の完了前に割込みを成立させることで表現する。
+
+成立条件: 割込み側の行動が、対象の `interruptibleUntil` 段階が終了するまでの残り時間より短い時間で到達すること。\
+割込み側は対象より後に動き出しても、対象が確定 (割込み不可になる時点) するまでに追いつける速さが必要になる。
+
+### 今後の検討: interrupt と intercept
+
+「割込み (interrupt)」と「迎撃 (intercept)」は別概念として扱い、それぞれ検討していく (現時点では未分離、区別せず記述している)。
+
+- interrupt: 対象の行動そのものを中断・変更させる (対象の `ActionPhase` 遷移を止める)。
+- intercept: 対象の行動は止めず、その結果 (命中・成立) に割って入る、または先に成立させる (対象の遷移は止まらない)。
+
+---
+
+## 5. プログラミング（C# / TypeScriptなど）での実装イメージ
 
 システム内でフェーズを管理するための `Enum（列挙型）` の定義例です。
 
@@ -102,5 +135,17 @@ enum ActionResultType {
     Critical,
     Evaded,
     Blocked
+}
+
+// 段階ごとの所要時間
+interface ActionTiming {
+    phase: ActionPhase;
+    durationMs: number; // この段階の遷移に要する時間
+}
+
+// 行動定義 (所要時間・割込み可能範囲を持つ)
+interface ActionDefinition {
+    interruptibleUntil: ActionPhase; // この段階の完了までは割込みを受け付ける
+    timings: ActionTiming[];         // 段階ごとの所要時間
 }
 ```

--- a/src/prototypes/time-control/time-control-02/README.md
+++ b/src/prototypes/time-control/time-control-02/README.md
@@ -1,0 +1,40 @@
+# TimeControl02
+
+複数キャラクター (actor) の移動と、action-phase 情報付きの行動履歴を管理するプロトタイプ。
+
+## 設計
+
+- 本体ロジックは `_stores/actor-store.ts` (zustand vanilla store) のみで完結する。React コンポーネントは動作確認用のデモに留める。
+- `list-rendering/list-02` と同様、store インスタンス (不変参照) を Context 経由で配布し、各コンポーネントは `useActorStore(selector)` で必要な部分だけ購読する。actor ごとの position 更新は、その actor の position を購読するコンポーネントのみを再レンダリングする。
+- 座標は自由 (`{ x, y }`)、初期値 `{ x: 0, y: 0 }`、クランプなし。
+
+## action-phase との対応
+
+`docs/concept/ideas/action-phase.md` の 企図(Intent) → 予備 → 実行 → 成否 → 事後(Resolution) の5段階のうち、`ActionPhase` 型は5段階すべてを表現できる。実際に発火するのは 企図(intent) → 実行(execution、tick 毎) → 事後(resolution、最終 tick) の3段階。予備動作・成否判定は対象外 (PreAction/Outcome は将来課題)。
+
+## 移動フロー (Intent → Execution)
+
+1. **set target** ボタン (actor ごと、`dispatchMoveIntent`): 移動先を宣言するのみ。この時点では `positionById` は変化しない。`speed`(距離/ms) と `tickMs`(後述) から1tickあたりの移動距離を求め、`generateMovePath` (`_lib/generate-move-path.ts`) で移動先までの経路 (`MovePath`) を生成し `movePathById` に格納する。
+2. **行動決定** ボタン (全 actor 一括、`ActionBar` コンポーネント): 各 actor の企図をまとめて実行する。actor ごとの `progressModeById` に応じて挙動が変わる。
+   - `manual`: 1回の押下で経路の先頭1 tick 分だけ進む (`actionLog` に `execution` を記録、最終 tick のみ `resolution`)。
+   - `auto`: 押下後、actor ごとの `tickMs` 間隔の内部タイマーで経路を最後まで自動消化する。
+3. **mode** ボタン (全 actor 一括、`ActionBar` コンポーネント): `auto`/`manual` を切り替える。actor ごとの個別切り替えは廃止、常に全員同一モードで揃える。
+
+## speed / tickRate
+
+移動に関する値は役割ごとに2つに分離している。
+
+- **speed** (`speedById`, 距離/ms): 実際の移動速度。1tickあたりの移動距離 (`stepDistance`) は `speed * tickMs` で決まる。
+- **tickRate** (`tickRateById`): tick の発生頻度。`getTickMs` (`_lib/get-tick-ms.ts`) により `tickMs = BASE_TICK_MS / tickRate` を求める。\
+  画面表示用の「敏捷性 (agility)」は将来別途追加予定のため、内部実装専用の値として `tickRate` という別名にしている (agility → tickRate の変換式は未定)。
+
+各 actor の `path.length * tickMs` が目標地点までの推定所要時間 (eta) になり、`ActorItem` に表示する。
+
+## スケジュールプレビュー
+
+`行動決定` を押す前に、各 actor の tick タイミングを実時間でマージした表 (`SchedulePreview`) を表示する。`_lib/build-schedule.ts` の `buildSchedule` が、actor ごとの残り経路 (`movePathById`) と `tickRateById` から `tickMs` の倍数でタイムスタンプを算出し、同一時刻に複数 actor の tick が重なる場合は1行にまとめる。実行エンジン (`dispatchAction` の actor 個別 `setTimeout` ループ) 自体は変更していないため、あくまで「このまま `行動決定` を押したらどうなるか」の予定表であり、実際のログ (`ActionLogPanel`) とは別コンポーネント。
+
+## スコープ外
+
+- 経路探索 (障害物回避)・境界処理 (クランプ/ワープ) は対象外。移動経路は直線を tick 刻みで分割するのみ。
+- PreAction (状態異常等の割り込み) / Outcome (成否判定) は将来課題。

--- a/src/prototypes/time-control/time-control-02/__tests__/actor-store.test.ts
+++ b/src/prototypes/time-control/time-control-02/__tests__/actor-store.test.ts
@@ -1,0 +1,189 @@
+import { createActorStore } from '../_stores/actor-store'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test('未移動 actor の position は保持されない', () => {
+  const store = createActorStore()
+
+  expect(store.getState().positionById.a).toBeUndefined()
+})
+
+test('dispatchMoveIntent は position を変更せず経路のみ生成する', () => {
+  const store = createActorStore()
+
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 6, y: 0 } })
+
+  expect(store.getState().positionById.a).toBeUndefined()
+  expect(store.getState().movePathById.a).toHaveLength(3)
+})
+
+test('dispatchMoveIntent は actionLog に intent のみ追加する', () => {
+  const store = createActorStore()
+
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 1, y: 1 } })
+
+  const log = store.getState().actionLog
+
+  expect(log).toHaveLength(1)
+  expect(log[0].event).toEqual({
+    actorId: 'a',
+    gameTimeMs: 0,
+    phase: 'intent',
+    target: { x: 1, y: 1 },
+  })
+})
+
+test('actionLog の gameTimeMs は tick の倍数になる決定論的な値', () => {
+  const store = createActorStore()
+
+  store.getState().setProgressMode('a', 'manual')
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 6, y: 0 } })
+  store.getState().dispatchAction('a')
+  store.getState().dispatchAction('a')
+  store.getState().dispatchAction('a')
+
+  const gameTimeMsList = store
+    .getState()
+    .actionLog.map((entry) => entry.event.gameTimeMs)
+
+  expect(gameTimeMsList).toEqual([0, 200, 400, 600])
+})
+
+test('dispatchAction (manual) は1回の呼び出しで1tickだけ進む', () => {
+  const store = createActorStore()
+
+  store.getState().setProgressMode('a', 'manual')
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 6, y: 0 } })
+
+  store.getState().dispatchAction('a')
+
+  expect(store.getState().positionById.a).toEqual({ x: 2, y: 0 })
+  expect(store.getState().movePathById.a).toHaveLength(2)
+  const log = store.getState().actionLog
+  expect(log[log.length - 1].event.phase).toBe('execution')
+
+  store.getState().dispatchAction('a')
+  store.getState().dispatchAction('a')
+
+  expect(store.getState().positionById.a).toEqual({ x: 6, y: 0 })
+  expect(store.getState().movePathById.a).toHaveLength(0)
+  const finalLog = store.getState().actionLog
+  expect(finalLog[finalLog.length - 1].event.phase).toBe('resolution')
+})
+
+test('dispatchAction (auto) はタイマーで最後まで自動進行する', () => {
+  const store = createActorStore()
+
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 6, y: 0 } })
+  store.getState().dispatchAction('a')
+
+  expect(store.getState().positionById.a).toEqual({ x: 2, y: 0 })
+
+  vi.advanceTimersByTime(200)
+  expect(store.getState().positionById.a).toEqual({ x: 4, y: 0 })
+
+  vi.advanceTimersByTime(200)
+  expect(store.getState().positionById.a).toEqual({ x: 6, y: 0 })
+  expect(store.getState().movePathById.a).toHaveLength(0)
+})
+
+test('speed が高い actor は1tickあたりの移動距離が長くなる', () => {
+  const store = createActorStore()
+
+  store.setState({ speedById: { a: 0.02 } }) // tickMs=200 -> stepDistance=4 (デフォルトの2倍)
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 8, y: 0 } })
+
+  expect(store.getState().movePathById.a).toHaveLength(2)
+})
+
+test('tickRate が高い actor は auto 進行の間隔が短くなる', () => {
+  const store = createActorStore()
+
+  // tickMs=400/4=100 (デフォルトの半分) -> stepDistance = 0.01 * 100 = 1
+  store.setState({ tickRateById: { a: 4 } })
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 2, y: 0 } })
+  store.getState().dispatchAction('a')
+
+  expect(store.getState().positionById.a).toEqual({ x: 1, y: 0 })
+
+  vi.advanceTimersByTime(100)
+  expect(store.getState().positionById.a).toEqual({ x: 2, y: 0 })
+})
+
+test('minPathStepsById を指定すると短距離の企図でも経路が最低 step 数に分割される', () => {
+  const store = createActorStore()
+
+  store.setState({ minPathStepsById: { a: 3 } })
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 1, y: 0 } })
+
+  expect(store.getState().movePathById.a).toHaveLength(3)
+})
+
+test('複数回の企図・行動決定をまたいでも gameTimeMs が衝突せず履歴が残り続ける', () => {
+  const store = createActorStore()
+
+  store.getState().setProgressMode('a', 'manual')
+
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 2, y: 0 } })
+  store.getState().dispatchAction('a')
+
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 4, y: 0 } })
+  store.getState().dispatchAction('a')
+
+  const gameTimeMsList = store
+    .getState()
+    .actionLog.filter((entry) => entry.event.phase !== 'intent')
+    .map((entry) => entry.event.gameTimeMs)
+
+  // 1回目: 200ms, 2回目: 400ms (0からリセットされず続けて数える)
+  expect(gameTimeMsList).toEqual([200, 400])
+  expect(new Set(gameTimeMsList).size).toBe(gameTimeMsList.length)
+})
+
+test('複数 actor の移動は互いの position/log に影響しない', () => {
+  const store = createActorStore()
+
+  store.getState().setProgressMode('a', 'manual')
+  store.getState().setProgressMode('b', 'manual')
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 2, y: 0 } })
+  store.getState().dispatchMoveIntent({ actorId: 'b', target: { x: 0, y: 2 } })
+  store.getState().dispatchAction('a')
+  store.getState().dispatchAction('b')
+
+  const state = store.getState()
+
+  expect(state.positionById).toEqual({
+    a: { x: 2, y: 0 },
+    b: { x: 0, y: 2 },
+  })
+  expect(state.actionLog.map((entry) => entry.event.actorId)).toEqual([
+    'a',
+    'b',
+    'a',
+    'b',
+  ])
+})
+
+test('reset で全 actor の状態が初期状態に戻る', () => {
+  const store = createActorStore()
+
+  store.getState().setProgressMode('a', 'manual')
+  store.getState().dispatchMoveIntent({ actorId: 'a', target: { x: 2, y: 0 } })
+  store.getState().dispatchAction('a')
+
+  store.getState().reset()
+
+  const state = store.getState()
+
+  expect(state.positionById).toEqual({})
+  expect(state.movePathById).toEqual({})
+  expect(state.actionLog).toEqual([])
+  expect(state.tickCountById).toEqual({})
+  expect(state.progressModeById).toEqual({})
+})

--- a/src/prototypes/time-control/time-control-02/__tests__/build-history.test.ts
+++ b/src/prototypes/time-control/time-control-02/__tests__/build-history.test.ts
@@ -1,0 +1,41 @@
+import { buildHistory } from '../_lib/build-history'
+import { ActionLogEntry, EventLog } from '../types'
+
+const entry = (
+  actorId: string,
+  gameTimeMs: number,
+  phase: ActionLogEntry['phase'],
+): EventLog<ActionLogEntry>[number] => ({
+  event: { actorId, gameTimeMs, phase, target: { x: 0, y: 0 } },
+  time: Date.now(),
+})
+
+test('actionLog が空なら空配列を返す', () => {
+  expect(buildHistory(['a'], [])).toEqual([])
+})
+
+test('intent は除外される', () => {
+  const log = [entry('a', 0, 'intent'), entry('a', 100, 'execution')]
+
+  expect(buildHistory(['a'], log)).toEqual([
+    { entryByActorId: { a: log[1].event }, gameTimeMs: 100 },
+  ])
+})
+
+test('同一 gameTimeMs の複数 actor は1行にまとまる', () => {
+  const log = [
+    entry('a', 100, 'execution'),
+    entry('b', 100, 'execution'),
+    entry('a', 200, 'resolution'),
+  ]
+
+  const history = buildHistory(['a', 'b'], log)
+
+  expect(history).toEqual([
+    {
+      entryByActorId: { a: log[0].event, b: log[1].event },
+      gameTimeMs: 100,
+    },
+    { entryByActorId: { a: log[2].event }, gameTimeMs: 200 },
+  ])
+})

--- a/src/prototypes/time-control/time-control-02/__tests__/build-schedule.test.ts
+++ b/src/prototypes/time-control/time-control-02/__tests__/build-schedule.test.ts
@@ -1,0 +1,62 @@
+import { buildSchedule } from '../_lib/build-schedule'
+import { BASE_TICK_MS } from '../_lib/get-tick-ms'
+
+test('空の経路しかない場合は空配列を返す', () => {
+  const schedule = buildSchedule(['a'], {}, {}, {})
+
+  expect(schedule).toEqual([])
+})
+
+test('単一 actor の経路は tickMs の倍数で行が並ぶ', () => {
+  const movePathById = {
+    a: [
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ],
+  }
+  const tickRateById = { a: BASE_TICK_MS / 100 } // tickMs = 100
+
+  const schedule = buildSchedule(['a'], movePathById, {}, tickRateById)
+
+  expect(schedule).toEqual([
+    { actorIds: ['a'], timeMs: 100 },
+    { actorIds: ['a'], timeMs: 200 },
+  ])
+})
+
+test('同時刻の tick は1行にまとめられる', () => {
+  // A: tickMs=100 -> 100,200,300 / B: tickMs=150 -> 150,300
+  const movePathById = {
+    a: [
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 3, y: 0 },
+    ],
+    b: [
+      { x: 0, y: 1 },
+      { x: 0, y: 2 },
+    ],
+  }
+  const tickRateById = {
+    a: BASE_TICK_MS / 100,
+    b: BASE_TICK_MS / 150,
+  }
+
+  const schedule = buildSchedule(['a', 'b'], movePathById, {}, tickRateById)
+
+  expect(schedule).toEqual([
+    { actorIds: ['a'], timeMs: 100 },
+    { actorIds: ['b'], timeMs: 150 },
+    { actorIds: ['a'], timeMs: 200 },
+    { actorIds: ['a', 'b'], timeMs: 300 },
+  ])
+})
+
+test('tickCountById の累積値から続けて数える (履歴と衝突しない)', () => {
+  const movePathById = { a: [{ x: 1, y: 0 }] }
+  const tickRateById = { a: BASE_TICK_MS / 100 } // tickMs = 100
+
+  const schedule = buildSchedule(['a'], movePathById, { a: 3 }, tickRateById)
+
+  expect(schedule).toEqual([{ actorIds: ['a'], timeMs: 400 }])
+})

--- a/src/prototypes/time-control/time-control-02/__tests__/generate-move-path.test.ts
+++ b/src/prototypes/time-control/time-control-02/__tests__/generate-move-path.test.ts
@@ -1,0 +1,62 @@
+import { generateMovePath } from '../_lib/generate-move-path'
+
+test('distance が 0 の場合は空配列を返す', () => {
+  expect(generateMovePath({ x: 1, y: 1 }, { x: 1, y: 1 }, 2)).toEqual([])
+})
+
+test('step数は distance / agility の切り上げになる', () => {
+  const path = generateMovePath({ x: 0, y: 0 }, { x: 10, y: 0 }, 3)
+
+  expect(path).toHaveLength(4)
+})
+
+test('最終要素は target と一致する', () => {
+  const path = generateMovePath({ x: 0, y: 0 }, { x: 10, y: 7 }, 3)
+
+  expect(path[path.length - 1]).toEqual({ x: 10, y: 7 })
+})
+
+test('minSteps 未指定なら短距離でも1 step (現行互換)', () => {
+  const path = generateMovePath({ x: 0, y: 0 }, { x: 1, y: 0 }, 10)
+
+  expect(path).toHaveLength(1)
+})
+
+test('minSteps を指定すると短距離でもその step 数以上に分割される', () => {
+  const path = generateMovePath({ x: 0, y: 0 }, { x: 1, y: 0 }, 10, 4)
+
+  expect(path).toHaveLength(4)
+  expect(path[path.length - 1]).toEqual({ x: 1, y: 0 })
+})
+
+test('minSteps より距離基準の step 数が多い場合は距離基準を優先する', () => {
+  const path = generateMovePath({ x: 0, y: 0 }, { x: 10, y: 0 }, 3, 2)
+
+  expect(path).toHaveLength(4)
+})
+
+test('最終 step 以外は stepDistance いっぱい移動する (端数を均等割りしない)', () => {
+  const path = generateMovePath({ x: 0, y: 0 }, { x: 10, y: 0 }, 3)
+
+  // 最終step以外 (3個): stepDistance(3)そのまま進む。最終stepのみ端数(1)
+  expect(path[0]).toEqual({ x: 3, y: 0 })
+  expect(path[1]).toEqual({ x: 6, y: 0 })
+  expect(path[2]).toEqual({ x: 9, y: 0 })
+  expect(path[3]).toEqual({ x: 10, y: 0 })
+})
+
+test('各 step は agility 以下の距離で進む', () => {
+  const from = { x: 0, y: 0 }
+  const agility = 3
+  const path = generateMovePath(from, { x: 10, y: 0 }, agility)
+
+  let previous = from
+  for (const step of path) {
+    const dx = step.x - previous.x
+    const dy = step.y - previous.y
+    const stepDistance = Math.sqrt(dx * dx + dy * dy)
+
+    expect(stepDistance).toBeLessThanOrEqual(agility + 1e-9)
+    previous = step
+  }
+})

--- a/src/prototypes/time-control/time-control-02/__tests__/generate-move-path.test.ts
+++ b/src/prototypes/time-control/time-control-02/__tests__/generate-move-path.test.ts
@@ -22,11 +22,15 @@ test('minSteps 未指定なら短距離でも1 step (現行互換)', () => {
   expect(path).toHaveLength(1)
 })
 
-test('minSteps を指定すると短距離でもその step 数以上に分割される', () => {
+test('minSteps が距離基準の step 数を上回る場合、各 step は stepDistance ぶん進み target を超えうる', () => {
   const path = generateMovePath({ x: 0, y: 0 }, { x: 1, y: 0 }, 10, 4)
 
-  expect(path).toHaveLength(4)
-  expect(path[path.length - 1]).toEqual({ x: 1, y: 0 })
+  expect(path).toEqual([
+    { x: 10, y: 0 },
+    { x: 20, y: 0 },
+    { x: 30, y: 0 },
+    { x: 40, y: 0 },
+  ])
 })
 
 test('minSteps より距離基準の step 数が多い場合は距離基準を優先する', () => {

--- a/src/prototypes/time-control/time-control-02/__tests__/get-tick-ms.test.ts
+++ b/src/prototypes/time-control/time-control-02/__tests__/get-tick-ms.test.ts
@@ -1,0 +1,10 @@
+import { BASE_TICK_MS, getTickMs } from '../_lib/get-tick-ms'
+
+test('tickMs は BASE_TICK_MS / agility になる', () => {
+  expect(getTickMs(2)).toBe(BASE_TICK_MS / 2)
+  expect(getTickMs(4)).toBe(BASE_TICK_MS / 4)
+})
+
+test('agility が高いほど tickMs は短くなる', () => {
+  expect(getTickMs(4)).toBeLessThan(getTickMs(2))
+})

--- a/src/prototypes/time-control/time-control-02/_components/action-bar/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/action-bar/index.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/ui/button'
+
+import { useActorStore } from '../../_contexts/actor-store-context'
+import { DEFAULT_PROGRESS_MODE } from '../../_stores/actor-store'
+import { ActorId } from '../../types'
+
+type ActionBarProps = {
+  /** 操作対象の actor 一覧 */
+  actorIds: ActorId[]
+}
+
+/**
+ * 全 actor 一括の操作パネル
+ *
+ * - 行動決定: 個別 actor の企図をまとめて実行する
+ * - mode: 進行モード (auto/manual) を全 actor 一括で切り替える。\
+ *   actor ごとの個別切り替えは廃止、常に全員同一モードで揃える
+ * - reset: 全 actor の状態を初期状態に戻す
+ */
+export const ActionBar = (props: ActionBarProps) => {
+  const { actorIds } = props
+
+  const progressMode = useActorStore(
+    (state) => state.progressModeById[actorIds[0]] ?? DEFAULT_PROGRESS_MODE,
+  )
+  const dispatchAction = useActorStore((state) => state.dispatchAction)
+  const reset = useActorStore((state) => state.reset)
+  const setProgressMode = useActorStore((state) => state.setProgressMode)
+
+  return (
+    <div className="flex gap-2 p-2">
+      <Button
+        onClick={() => {
+          actorIds.forEach((id) => dispatchAction(id))
+        }}
+        type="button"
+      >
+        行動決定
+      </Button>
+      <Button
+        onClick={() => {
+          const nextMode = progressMode === 'auto' ? 'manual' : 'auto'
+          actorIds.forEach((id) => setProgressMode(id, nextMode))
+        }}
+        type="button"
+        variant="outline"
+      >
+        mode: {progressMode}
+      </Button>
+      <Button onClick={reset} type="button" variant="destructive">
+        reset
+      </Button>
+    </div>
+  )
+}

--- a/src/prototypes/time-control/time-control-02/_components/action-log-panel/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/action-log-panel/index.tsx
@@ -1,0 +1,66 @@
+import {
+  TableBody,
+  TableCell,
+  TableElement,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import { useActorStore } from '../../_contexts/actor-store-context'
+import { buildHistory } from '../../_lib/build-history'
+import { ActorId } from '../../types'
+
+type ActionLogPanelProps = {
+  /** 列として表示する actor の一覧 */
+  actorIds: ActorId[]
+}
+
+/**
+ * actionLog のみを購読する履歴パネル。actor の position 更新では再レンダリングされない
+ *
+ * - `SchedulePreview` と同じ構造: 先頭に経過時間 (`gameTimeMs`) 列、続けて actor 列
+ * - `gameTimeMs` は tick 由来の決定論的な値 (実時刻の揺らぎを含まない) のため、\
+ *   同一 tick で複数 actor が行動した場合は1行にまとまる
+ * - intent は actor 行 (`ActorItem`) 側で表示するため、タイムラインには含めない
+ */
+export const ActionLogPanel = (props: ActionLogPanelProps) => {
+  const { actorIds } = props
+
+  const actionLog = useActorStore((state) => state.actionLog)
+
+  const rows = buildHistory(actorIds, actionLog)
+
+  return (
+    <TableElement className="table-fixed">
+      <TableHeader>
+        <TableRow>
+          <TableHead>経過時間</TableHead>
+          {actorIds.map((id) => (
+            <TableHead key={id}>{id}</TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row) => (
+          <TableRow key={row.gameTimeMs}>
+            <TableCell className="whitespace-nowrap">
+              {row.gameTimeMs}ms
+            </TableCell>
+            {actorIds.map((id) => {
+              const entry = row.entryByActorId[id]
+
+              return (
+                <TableCell className="whitespace-nowrap" key={id}>
+                  {entry
+                    ? `${entry.phase} (${entry.target.x}, ${entry.target.y})`
+                    : ''}
+                </TableCell>
+              )
+            })}
+          </TableRow>
+        ))}
+      </TableBody>
+    </TableElement>
+  )
+}

--- a/src/prototypes/time-control/time-control-02/_components/action-log-panel/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/action-log-panel/index.tsx
@@ -9,6 +9,7 @@ import {
 
 import { useActorStore } from '../../_contexts/actor-store-context'
 import { buildHistory } from '../../_lib/build-history'
+import { formatCoord } from '../../_lib/format-coord'
 import { ActorId } from '../../types'
 
 type ActionLogPanelProps = {
@@ -53,7 +54,7 @@ export const ActionLogPanel = (props: ActionLogPanelProps) => {
               return (
                 <TableCell className="whitespace-nowrap" key={id}>
                   {entry
-                    ? `${entry.phase} (${entry.target.x}, ${entry.target.y})`
+                    ? `${entry.phase} (${formatCoord(entry.target.x)}, ${formatCoord(entry.target.y)})`
                     : ''}
                 </TableCell>
               )

--- a/src/prototypes/time-control/time-control-02/_components/actor-item/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/actor-item/index.tsx
@@ -1,0 +1,93 @@
+import { memo } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+import { useActorStore } from '../../_contexts/actor-store-context'
+import { getTickMs } from '../../_lib/get-tick-ms'
+import {
+  DEFAULT_MIN_PATH_STEPS,
+  DEFAULT_POSITION,
+  DEFAULT_TICK_RATE,
+} from '../../_stores/actor-store'
+import { ActorId } from '../../types'
+
+type ActorItemProps = {
+  /** 表示対象の actor */
+  id: ActorId
+}
+
+/**
+ * actor 1体分の表示・操作
+ *
+ * - memo + 自身の id のみを鍵にした selector により、他 actor の移動では\
+ *   再レンダリングされない
+ * - `set target` (企図) → 全体一括の `行動決定`/`mode` (実行、`ActionBar` 側に設置) の2段階操作。\
+ *   `set target` の時点では position は動かない
+ * - 現在の企図 (intent) は経路 (`movePathById`) の最終要素 (= target) から表示する。\
+ *   経路が空なら企図なし/到達済み
+ */
+export const ActorItem = memo((props: ActorItemProps) => {
+  const { id } = props
+
+  const position = useActorStore(
+    (state) => state.positionById[id] ?? DEFAULT_POSITION,
+  )
+  const path = useActorStore((state) => state.movePathById[id] ?? [])
+  const tickRate = useActorStore(
+    (state) => state.tickRateById[id] ?? DEFAULT_TICK_RATE,
+  )
+  const minPathSteps = useActorStore(
+    (state) => state.minPathStepsById[id] ?? DEFAULT_MIN_PATH_STEPS,
+  )
+  const intentTarget = path[path.length - 1]
+  const etaMs = path.length * getTickMs(tickRate)
+  const dispatchMoveIntent = useActorStore((state) => state.dispatchMoveIntent)
+  const setMinPathSteps = useActorStore((state) => state.setMinPathSteps)
+
+  return (
+    <li className="flex items-center gap-2 whitespace-nowrap border-b border-solid border-gray-200 p-2">
+      <span className="min-w-16 text-gray-400">{id}</span>
+      <span className="min-w-20">
+        ({position.x}, {position.y})
+      </span>
+      <span className="min-w-16 text-gray-400">path: {path.length}</span>
+      <span className="min-w-28 text-gray-400">
+        target: {intentTarget ? `(${intentTarget.x}, ${intentTarget.y})` : '-'}
+      </span>
+      <span className="min-w-24 text-gray-400">eta: {etaMs}ms</span>
+      <label className="flex items-center gap-1 text-gray-400">
+        min:
+        <input
+          className="w-12 rounded border border-solid border-gray-300 px-1"
+          min={1}
+          onChange={(event) => {
+            // 入力途中 (空文字/0 等) も含めそのまま反映する。\
+            // 厳密な下限チェックは使用時 (dispatchMoveIntent) 側で行う。\
+            // ここで弾くと controlled input の value が古い値に押し戻され、\
+            // 入力中の値が消えて事実上編集不能になる
+            setMinPathSteps(id, Number(event.target.value))
+          }}
+          type="number"
+          value={minPathSteps}
+        />
+      </label>
+      <Button
+        onClick={() => {
+          dispatchMoveIntent({
+            actorId: id,
+            target: {
+              x: position.x + Math.round(Math.random() * 6 - 3),
+              y: position.y + Math.round(Math.random() * 6 - 3),
+            },
+          })
+        }}
+        size="sm"
+        type="button"
+      >
+        set target
+      </Button>
+    </li>
+  )
+})
+
+ActorItem.displayName = 'ActorItem'

--- a/src/prototypes/time-control/time-control-02/_components/actor-item/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/actor-item/index.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react'
 import { Button } from '@/components/ui/button'
 
 import { useActorStore } from '../../_contexts/actor-store-context'
+import { formatCoord } from '../../_lib/format-coord'
 import { getTickMs } from '../../_lib/get-tick-ms'
 import {
   DEFAULT_MIN_PATH_STEPS,
@@ -48,11 +49,14 @@ export const ActorItem = memo((props: ActorItemProps) => {
     <li className="flex items-center gap-2 whitespace-nowrap border-b border-solid border-gray-200 p-2">
       <span className="min-w-16 text-gray-400">{id}</span>
       <span className="min-w-20">
-        ({position.x}, {position.y})
+        ({formatCoord(position.x)}, {formatCoord(position.y)})
       </span>
       <span className="min-w-16 text-gray-400">path: {path.length}</span>
       <span className="min-w-28 text-gray-400">
-        target: {intentTarget ? `(${intentTarget.x}, ${intentTarget.y})` : '-'}
+        target:{' '}
+        {intentTarget
+          ? `(${formatCoord(intentTarget.x)}, ${formatCoord(intentTarget.y)})`
+          : '-'}
       </span>
       <span className="min-w-24 text-gray-400">eta: {etaMs}ms</span>
       <label className="flex items-center gap-1 text-gray-400">

--- a/src/prototypes/time-control/time-control-02/_components/actor-marker/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/actor-marker/index.tsx
@@ -1,0 +1,63 @@
+import { memo } from 'react'
+
+import { useActorStore } from '../../_contexts/actor-store-context'
+import { toPixelStyle } from '../../_lib/stage-coords'
+import { DEFAULT_POSITION } from '../../_stores/actor-store'
+import { ActorId } from '../../types'
+
+type ActorMarkerProps = {
+  /** 表示対象の actor */
+  id: ActorId
+}
+
+/**
+ * actor 1体分の CSS 絶対位置表示 (現在位置 + 残り経路 + 移動軌跡)
+ *
+ * - memo + 自身の id のみを鍵にした selector により、他 actor の移動では再レンダリングされない\
+ *   (ただし軌跡は actionLog 全体を購読するため、他 actor の行動決定でも再レンダリングされる。\
+ *   `ActionLogPanel`/`SchedulePreview` と同じ許容範囲)
+ * - 軌跡 (行動履歴) は消化済みの経路点であっても消さず、actionLog から都度導出して残し続ける
+ */
+export const ActorMarker = memo((props: ActorMarkerProps) => {
+  const { id } = props
+
+  const position = useActorStore(
+    (state) => state.positionById[id] ?? DEFAULT_POSITION,
+  )
+  const path = useActorStore((state) => state.movePathById[id] ?? [])
+  const trail = useActorStore((state) =>
+    state.actionLog
+      .filter(
+        (entry) => entry.event.actorId === id && entry.event.phase !== 'intent',
+      )
+      .map((entry) => entry.event.target),
+  )
+
+  return (
+    <>
+      {trail.map((step, index) => (
+        <div
+          className="absolute size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-200"
+          key={index}
+          style={toPixelStyle(step)}
+        />
+      ))}
+      {path.map((step, index) => (
+        <div
+          className="absolute size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-gray-300"
+          key={index}
+          style={toPixelStyle(step)}
+        />
+      ))}
+      <div
+        className="absolute flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-blue-600 text-[10px] font-bold text-white"
+        style={toPixelStyle(position)}
+        title={id}
+      >
+        {id.split('-').pop()}
+      </div>
+    </>
+  )
+})
+
+ActorMarker.displayName = 'ActorMarker'

--- a/src/prototypes/time-control/time-control-02/_components/schedule-preview/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/schedule-preview/index.tsx
@@ -1,0 +1,67 @@
+import {
+  TableBody,
+  TableCell,
+  TableElement,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import { useActorStore } from '../../_contexts/actor-store-context'
+import { buildSchedule } from '../../_lib/build-schedule'
+import { ActorId } from '../../types'
+
+type SchedulePreviewProps = {
+  /** 列として表示する actor の一覧 */
+  actorIds: ActorId[]
+}
+
+/**
+ * 行動決定前のスケジュールプレビュー
+ *
+ * - 各 actor の残り経路 (`movePathById`) から tick タイミングを実時間でマージし、\
+ *   同時刻の tick は1行にまとめて表示する
+ * - `movePathById`/`tickRateById` 全体を購読するため、いずれかの actor の経路が\
+ *   変化するたびに再レンダリングされる (プレビュー用途のため許容)
+ * - 経過時間は行ごとに専用列 (先頭) へまとめる。actor 列には行動の有無のみ表示する\
+ *   (同一行に複数 actor が並ぶ場合、経過時間を列ごとに重複表示しないため)
+ */
+export const SchedulePreview = (props: SchedulePreviewProps) => {
+  const { actorIds } = props
+
+  const movePathById = useActorStore((state) => state.movePathById)
+  const tickCountById = useActorStore((state) => state.tickCountById)
+  const tickRateById = useActorStore((state) => state.tickRateById)
+
+  const schedule = buildSchedule(
+    actorIds,
+    movePathById,
+    tickCountById,
+    tickRateById,
+  )
+
+  return (
+    <TableElement className="table-fixed">
+      <TableHeader>
+        <TableRow>
+          <TableHead>経過時間</TableHead>
+          {actorIds.map((id) => (
+            <TableHead key={id}>{id}</TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {schedule.map((row) => (
+          <TableRow key={row.timeMs}>
+            <TableCell className="whitespace-nowrap">{row.timeMs}ms</TableCell>
+            {actorIds.map((id) => (
+              <TableCell className="whitespace-nowrap" key={id}>
+                {row.actorIds.includes(id) ? '●' : ''}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </TableElement>
+  )
+}

--- a/src/prototypes/time-control/time-control-02/_components/stage-view/index.tsx
+++ b/src/prototypes/time-control/time-control-02/_components/stage-view/index.tsx
@@ -1,0 +1,29 @@
+import { STAGE_SIZE } from '../../_lib/stage-coords'
+import { ActorId } from '../../types'
+import { ActorMarker } from '../actor-marker'
+
+type StageViewProps = {
+  /** 表示する actor の一覧 */
+  actorIds: ActorId[]
+}
+
+/**
+ * actor の座標を CSS の絶対位置で表現する stage
+ *
+ * - Position { x: 0, y: 0 } を中央に、y 下向きの screen 座標系のまま `top`/`left` に対応させる
+ * - 現在位置に加え、残り経路 (`movePathById`) の各点も表示する
+ */
+export const StageView = (props: StageViewProps) => {
+  const { actorIds } = props
+
+  return (
+    <div
+      className="relative border border-solid border-gray-300 bg-gray-50"
+      style={{ height: STAGE_SIZE, width: STAGE_SIZE }}
+    >
+      {actorIds.map((id) => (
+        <ActorMarker id={id} key={id} />
+      ))}
+    </div>
+  )
+}

--- a/src/prototypes/time-control/time-control-02/_contexts/actor-store-context.tsx
+++ b/src/prototypes/time-control/time-control-02/_contexts/actor-store-context.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react'
+import { useStore } from 'zustand'
+
+import { ActorState, ActorStore } from '../_stores/actor-store'
+
+/**
+ * store インスタンス (参照は不変) のみを配布する
+ *
+ * - value に state 自体を含めないため、dispatchMoveIntent による state 変更では\
+ *   Context 自体は再生成されず、Provider 配下の再レンダリングは発生しない
+ */
+export const ActorStoreContext = createContext<ActorStore | null>(null)
+
+export const useActorStore = <T,>(selector: (state: ActorState) => T): T => {
+  const store = useContext(ActorStoreContext)
+
+  if (store === null) {
+    throw new Error(
+      'useActorStore should be used within <ActorStoreContext.Provider>',
+    )
+  }
+
+  return useStore(store, selector)
+}

--- a/src/prototypes/time-control/time-control-02/_lib/build-history.ts
+++ b/src/prototypes/time-control/time-control-02/_lib/build-history.ts
@@ -1,0 +1,35 @@
+import { ActionLogEntry, ActorId, EventLog, HistoryRow } from '../types'
+
+/**
+ * actionLog から、gameTimeMs でマージした履歴行を生成する
+ *
+ * - 同一 gameTimeMs の複数 actor は1行にまとめる (`buildSchedule` と同じ方針)
+ * - intent は対象外 (actor 行側で表示するため)
+ *
+ * @param actorIds 対象 actor 一覧
+ * @param actionLog 行動履歴
+ */
+export const buildHistory = (
+  actorIds: ActorId[],
+  actionLog: EventLog<ActionLogEntry>,
+): HistoryRow[] => {
+  const entryByActorIdByTime = new Map<
+    number,
+    Partial<Record<ActorId, ActionLogEntry>>
+  >()
+
+  for (const { event } of actionLog) {
+    if (event.phase === 'intent' || !actorIds.includes(event.actorId)) {
+      continue
+    }
+
+    const row = entryByActorIdByTime.get(event.gameTimeMs) ?? {}
+
+    row[event.actorId] = event
+    entryByActorIdByTime.set(event.gameTimeMs, row)
+  }
+
+  return [...entryByActorIdByTime.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([gameTimeMs, entryByActorId]) => ({ entryByActorId, gameTimeMs }))
+}

--- a/src/prototypes/time-control/time-control-02/_lib/build-schedule.ts
+++ b/src/prototypes/time-control/time-control-02/_lib/build-schedule.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_TICK_RATE } from '../_stores/actor-store'
+import { ActorId, MovePath, ScheduleRow } from '../types'
+
+import { getTickMs } from './get-tick-ms'
+
+/**
+ * 各 actor の残り経路から、tick タイミングを実時間でマージしたスケジュールを生成する
+ *
+ * - 同一時刻に複数 actor の tick が重なる場合は1行にまとめる
+ * - `tickCountById` (累積 tick 数) を起点に数えるため、履歴 (`buildHistory`) の\
+ *   `gameTimeMs` と連続した絶対時間になる
+ *
+ * @param actorIds 対象 actor 一覧
+ * @param movePathById actor ごとの残り経路
+ * @param tickCountById actor ごとの累積 tick 数
+ * @param tickRateById actor ごとの tick 発生頻度
+ */
+export const buildSchedule = (
+  actorIds: ActorId[],
+  movePathById: Record<ActorId, MovePath>,
+  tickCountById: Record<ActorId, number>,
+  tickRateById: Record<ActorId, number>,
+): ScheduleRow[] => {
+  const actorIdsByTime = new Map<number, ActorId[]>()
+
+  for (const actorId of actorIds) {
+    const path = movePathById[actorId] ?? []
+    const tickCount = tickCountById[actorId] ?? 0
+    const tickMs = getTickMs(tickRateById[actorId] ?? DEFAULT_TICK_RATE)
+
+    path.forEach((_, index) => {
+      const timeMs = (tickCount + index + 1) * tickMs
+      const list = actorIdsByTime.get(timeMs) ?? []
+
+      list.push(actorId)
+      actorIdsByTime.set(timeMs, list)
+    })
+  }
+
+  return [...actorIdsByTime.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([timeMs, ids]) => ({ actorIds: ids, timeMs }))
+}

--- a/src/prototypes/time-control/time-control-02/_lib/format-coord.ts
+++ b/src/prototypes/time-control/time-control-02/_lib/format-coord.ts
@@ -1,0 +1,7 @@
+/**
+ * 座標値を画面表示用に丸める
+ *
+ * @param value 丸め対象の座標値
+ */
+export const formatCoord = (value: number): number =>
+  Math.round(value * 1000) / 1000

--- a/src/prototypes/time-control/time-control-02/_lib/generate-move-path.ts
+++ b/src/prototypes/time-control/time-control-02/_lib/generate-move-path.ts
@@ -3,22 +3,24 @@ import { MovePath, Position } from '../types'
 /**
  * 現在地から目標地点までを、tick あたりの移動距離 (stepDistance) で刻んだ経路を生成する
  *
- * - 最終 step 以外は必ず `stepDistance` ぶん (= actor の移動可能距離いっぱい) 進む。\
- *   最終 step のみ端数を吸収して target に一致させる (目的地前の減速・最終調整)
- * - 距離が短く `stepDistance` から求めた step 数が `minSteps` 未満になる場合のみ、\
- *   例外的に均等分割で `minSteps` を満たす (この場合は step ごとの移動距離が\
- *   `stepDistance` より短くなる)
+ * - `minSteps` が距離基準の step 数 (`distance / stepDistance` の切り上げ) 以下、\
+ *   または `minSteps` が 0 (未使用) の場合: 到達地点 (`to`) を先に決定し、そこまでの\
+ *   距離を `stepDistance` で割って step 数を算出する。最終 step 以外は必ず\
+ *   `stepDistance` ぶん進み、最終 step のみ端数を吸収して target に一致させる
+ * - `minSteps` が距離基準の step 数を上回る場合: step 数 (`minSteps`) を先に決定し、\
+ *   各 step は進行方向 (`from` → `to`) へ必ず `stepDistance` ぶん進む。\
+ *   この場合 target を超えて進みうる (至近距離での移動調整を想定した例外経路)
  *
  * @param from 現在地
- * @param to 目標地点
+ * @param to 目標地点 (進行方向の基準)
  * @param stepDistance tick あたりの移動距離 (speed * tickMs)
- * @param minSteps 経路の最低 step 数
+ * @param minSteps 経路の最低 step 数。0 は未使用
  */
 export const generateMovePath = (
   from: Position,
   to: Position,
   stepDistance: number,
-  minSteps = 1,
+  minSteps = 0,
 ): MovePath => {
   const dx = to.x - from.x
   const dy = to.y - from.y
@@ -28,21 +30,20 @@ export const generateMovePath = (
     return []
   }
 
-  const naturalStepCount = Math.ceil(distance / stepDistance)
+  const dirX = dx / distance
+  const dirY = dy / distance
+  const distanceBasedSteps = Math.ceil(distance / stepDistance)
 
-  if (naturalStepCount < minSteps) {
+  if (minSteps > distanceBasedSteps) {
     return Array.from({ length: minSteps }, (_, index) => {
-      const ratio = Math.min((index + 1) / minSteps, 1)
+      const traveled = (index + 1) * stepDistance
 
-      return { x: from.x + dx * ratio, y: from.y + dy * ratio }
+      return { x: from.x + dirX * traveled, y: from.y + dirY * traveled }
     })
   }
 
-  const dirX = dx / distance
-  const dirY = dy / distance
-
-  return Array.from({ length: naturalStepCount }, (_, index) => {
-    const isLastStep = index === naturalStepCount - 1
+  return Array.from({ length: distanceBasedSteps }, (_, index) => {
+    const isLastStep = index === distanceBasedSteps - 1
 
     if (isLastStep) {
       return { x: to.x, y: to.y }

--- a/src/prototypes/time-control/time-control-02/_lib/generate-move-path.ts
+++ b/src/prototypes/time-control/time-control-02/_lib/generate-move-path.ts
@@ -1,0 +1,55 @@
+import { MovePath, Position } from '../types'
+
+/**
+ * 現在地から目標地点までを、tick あたりの移動距離 (stepDistance) で刻んだ経路を生成する
+ *
+ * - 最終 step 以外は必ず `stepDistance` ぶん (= actor の移動可能距離いっぱい) 進む。\
+ *   最終 step のみ端数を吸収して target に一致させる (目的地前の減速・最終調整)
+ * - 距離が短く `stepDistance` から求めた step 数が `minSteps` 未満になる場合のみ、\
+ *   例外的に均等分割で `minSteps` を満たす (この場合は step ごとの移動距離が\
+ *   `stepDistance` より短くなる)
+ *
+ * @param from 現在地
+ * @param to 目標地点
+ * @param stepDistance tick あたりの移動距離 (speed * tickMs)
+ * @param minSteps 経路の最低 step 数
+ */
+export const generateMovePath = (
+  from: Position,
+  to: Position,
+  stepDistance: number,
+  minSteps = 1,
+): MovePath => {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const distance = Math.sqrt(dx * dx + dy * dy)
+
+  if (distance === 0) {
+    return []
+  }
+
+  const naturalStepCount = Math.ceil(distance / stepDistance)
+
+  if (naturalStepCount < minSteps) {
+    return Array.from({ length: minSteps }, (_, index) => {
+      const ratio = Math.min((index + 1) / minSteps, 1)
+
+      return { x: from.x + dx * ratio, y: from.y + dy * ratio }
+    })
+  }
+
+  const dirX = dx / distance
+  const dirY = dy / distance
+
+  return Array.from({ length: naturalStepCount }, (_, index) => {
+    const isLastStep = index === naturalStepCount - 1
+
+    if (isLastStep) {
+      return { x: to.x, y: to.y }
+    }
+
+    const traveled = (index + 1) * stepDistance
+
+    return { x: from.x + dirX * traveled, y: from.y + dirY * traveled }
+  })
+}

--- a/src/prototypes/time-control/time-control-02/_lib/get-tick-ms.ts
+++ b/src/prototypes/time-control/time-control-02/_lib/get-tick-ms.ts
@@ -1,0 +1,12 @@
+/** tick の実時間長を求める基準値 */
+export const BASE_TICK_MS = 400
+
+/**
+ * tickRate から tick の実時間長を求める
+ *
+ * - tickRate は内部実装用の値。画面表示用の「敏捷性 (agility)」は将来\
+ *   別途追加予定、両者は別名にしておく (agility → tickRate への変換式は未定)
+ *
+ * @param tickRate tick の発生頻度
+ */
+export const getTickMs = (tickRate: number): number => BASE_TICK_MS / tickRate

--- a/src/prototypes/time-control/time-control-02/_lib/stage-coords.ts
+++ b/src/prototypes/time-control/time-control-02/_lib/stage-coords.ts
@@ -1,0 +1,16 @@
+import { Position } from '../types'
+
+/** stage の一辺の長さ (px) */
+export const STAGE_SIZE = 300
+
+/** stage 中央の座標 (px)。Position { x: 0, y: 0 } をここに対応させる */
+export const STAGE_CENTER = STAGE_SIZE / 2
+
+/** Position 1単位あたりの px 数 */
+export const STAGE_SCALE = 20
+
+/** Position を stage 上の CSS 絶対位置 (px) に変換する */
+export const toPixelStyle = (position: Position) => ({
+  left: STAGE_CENTER + position.x * STAGE_SCALE,
+  top: STAGE_CENTER + position.y * STAGE_SCALE,
+})

--- a/src/prototypes/time-control/time-control-02/_stores/actor-store.ts
+++ b/src/prototypes/time-control/time-control-02/_stores/actor-store.ts
@@ -1,0 +1,193 @@
+import { createStore, StoreApi } from 'zustand/vanilla'
+
+import { generateMovePath } from '../_lib/generate-move-path'
+import { getTickMs } from '../_lib/get-tick-ms'
+import {
+  ActionLogEntry,
+  ActorId,
+  EventLog,
+  MoveIntent,
+  MovePath,
+  Position,
+  ProgressMode,
+} from '../types'
+
+export type ActorState = {
+  /** 時系列の行動履歴 */
+  actionLog: EventLog<ActionLogEntry>
+  /** 行動決定。経路に沿って1tick分 (手動時) または最後まで (自動時) 進行する */
+  dispatchAction: (actorId: ActorId) => void
+  /** 移動企図。経路を生成するのみで position は更新しない */
+  dispatchMoveIntent: (intent: MoveIntent) => void
+  /** actor ごとの経路の最低 step 数 */
+  minPathStepsById: Record<ActorId, number>
+  /** actor ごとの残り移動経路 */
+  movePathById: Record<ActorId, MovePath>
+  /** actor ごとの現在位置。未移動の actor は含まれない */
+  positionById: Record<ActorId, Position>
+  /** actor ごとの行動進行モード */
+  progressModeById: Record<ActorId, ProgressMode>
+  /** 全 actor の状態を初期状態に戻す (実行中の auto タイマーは次回発火時に無害な no-op となる) */
+  reset: () => void
+  /** 経路の最低 step 数を設定する */
+  setMinPathSteps: (actorId: ActorId, minSteps: number) => void
+  /** 行動進行モードを設定する */
+  setProgressMode: (actorId: ActorId, mode: ProgressMode) => void
+  /** actor ごとの移動速度 (距離/ms) */
+  speedById: Record<ActorId, number>
+  /**
+   * actor ごとの累積 tick 数 (gameTimeMs 算出用)
+   *
+   * - 企図 (dispatchMoveIntent) では リセットしない。複数回の企図・行動決定をまたいで\
+   *   増え続ける絶対的なゲームクロックとして扱う (履歴が企図のたびに重複・上書きされないため)
+   */
+  tickCountById: Record<ActorId, number>
+  /** actor ごとの tick 発生頻度。画面表示用の「敏捷性」とは別名にしている (未確定の変換式) */
+  tickRateById: Record<ActorId, number>
+}
+
+export type ActorStore = StoreApi<ActorState>
+
+/** 未移動 actor のデフォルト座標 */
+export const DEFAULT_POSITION: Position = { x: 0, y: 0 }
+
+/** 移動速度未設定 actor のデフォルト値 (距離/ms) */
+export const DEFAULT_SPEED = 0.01
+
+/** tick 発生頻度未設定 actor のデフォルト値 */
+export const DEFAULT_TICK_RATE = 2
+
+/** 経路の最低 step 数未設定 actor のデフォルト値 */
+export const DEFAULT_MIN_PATH_STEPS = 1
+
+/** 進行モード未設定 actor のデフォルト値 */
+export const DEFAULT_PROGRESS_MODE: ProgressMode = 'auto'
+
+/**
+ * time-control-02 インスタンスごとに独立した store を生成する
+ *
+ * - 経路探索や PreAction/Outcome の割り込みは対象外 (stage-04 と同じスコープ)
+ * - 移動は 企図 (Intent) → 経路生成 → 行動決定 (Execution、tick 刻み) → 事後 (Resolution) の\
+ *   順で進行する。企図の時点では position を更新しない
+ * - 経路の1tickあたりの移動距離は speed(距離/ms) と tickMs (tickRate から算出) の積で決まる
+ * - dispatchAction は対象 actor の positionById/movePathById のみ更新するため、\
+ *   他 actor の position を購読するコンポーネントは再レンダリングされない
+ */
+/** リセット時に戻す初期状態 */
+const INITIAL_STATE = {
+  actionLog: [],
+  minPathStepsById: {},
+  movePathById: {},
+  positionById: {},
+  progressModeById: {},
+  speedById: {},
+  tickCountById: {},
+  tickRateById: {},
+} satisfies Partial<ActorState>
+
+export const createActorStore = (): ActorStore =>
+  createStore<ActorState>((set, get) => ({
+    ...INITIAL_STATE,
+    dispatchAction: (actorId) => {
+      const applyNextStep = () => {
+        set((state) => {
+          const [nextStep, ...rest] = state.movePathById[actorId] ?? []
+
+          if (!nextStep) {
+            return state
+          }
+
+          const tickCount = (state.tickCountById[actorId] ?? 0) + 1
+          const tickMs = getTickMs(
+            state.tickRateById[actorId] ?? DEFAULT_TICK_RATE,
+          )
+
+          return {
+            actionLog: [
+              ...state.actionLog,
+              {
+                event: {
+                  actorId,
+                  gameTimeMs: tickCount * tickMs,
+                  phase: rest.length === 0 ? 'resolution' : 'execution',
+                  target: nextStep,
+                },
+                time: Date.now(),
+              },
+            ],
+            movePathById: { ...state.movePathById, [actorId]: rest },
+            positionById: { ...state.positionById, [actorId]: nextStep },
+            tickCountById: { ...state.tickCountById, [actorId]: tickCount },
+          }
+        })
+      }
+
+      applyNextStep()
+
+      const mode = get().progressModeById[actorId] ?? DEFAULT_PROGRESS_MODE
+
+      if (mode === 'auto') {
+        const tickMs = getTickMs(
+          get().tickRateById[actorId] ?? DEFAULT_TICK_RATE,
+        )
+
+        const continueAuto = () => {
+          if ((get().movePathById[actorId] ?? []).length === 0) {
+            return
+          }
+
+          applyNextStep()
+          setTimeout(continueAuto, tickMs)
+        }
+
+        setTimeout(continueAuto, tickMs)
+      }
+    },
+    dispatchMoveIntent: (intent) => {
+      const { actorId, target } = intent
+
+      set((state) => {
+        const from = state.positionById[actorId] ?? DEFAULT_POSITION
+        const speed = state.speedById[actorId] ?? DEFAULT_SPEED
+        const tickMs = getTickMs(
+          state.tickRateById[actorId] ?? DEFAULT_TICK_RATE,
+        )
+        const stepDistance = speed * tickMs
+        const minSteps = Math.max(
+          1,
+          state.minPathStepsById[actorId] ?? DEFAULT_MIN_PATH_STEPS,
+        )
+        const path = generateMovePath(from, target, stepDistance, minSteps)
+        const tickCount = state.tickCountById[actorId] ?? 0
+
+        return {
+          actionLog: [
+            ...state.actionLog,
+            {
+              event: {
+                actorId,
+                gameTimeMs: tickCount * tickMs,
+                phase: 'intent',
+                target,
+              },
+              time: Date.now(),
+            },
+          ],
+          movePathById: { ...state.movePathById, [actorId]: path },
+        }
+      })
+    },
+    reset: () => {
+      set(INITIAL_STATE)
+    },
+    setMinPathSteps: (actorId, minSteps) => {
+      set((state) => ({
+        minPathStepsById: { ...state.minPathStepsById, [actorId]: minSteps },
+      }))
+    },
+    setProgressMode: (actorId, mode) => {
+      set((state) => ({
+        progressModeById: { ...state.progressModeById, [actorId]: mode },
+      }))
+    },
+  }))

--- a/src/prototypes/time-control/time-control-02/index.stories.tsx
+++ b/src/prototypes/time-control/time-control-02/index.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { TimeControl02 as StoryComponent } from '.'
+
+const meta: Meta<typeof StoryComponent> = {
+  component: StoryComponent,
+}
+
+export default meta
+type Story = StoryObj<typeof StoryComponent>
+
+export const Primary: Story = {
+  args: {
+    actorIds: ['actor-a', 'actor-b', 'actor-c'],
+  },
+}

--- a/src/prototypes/time-control/time-control-02/index.tsx
+++ b/src/prototypes/time-control/time-control-02/index.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+
+import { ActionBar } from './_components/action-bar'
+import { ActionLogPanel } from './_components/action-log-panel'
+import { ActorItem } from './_components/actor-item'
+import { SchedulePreview } from './_components/schedule-preview'
+import { StageView } from './_components/stage-view'
+import { ActorStoreContext } from './_contexts/actor-store-context'
+import { createActorStore } from './_stores/actor-store'
+import { ActorId } from './types'
+
+type TimeControl02Props = {
+  /** 表示する actor の一覧 */
+  actorIds: ActorId[]
+}
+
+/**
+ * 複数 actor の移動と履歴管理のデモ
+ *
+ * - actor ごとに `aim` (企図) のみ行い、`行動決定` (実行) は全 actor 一括で\
+ *   `ActionBar` から行う
+ * - 履歴パネルは actionLog のみ、各 actor 行は自身の position のみを購読する
+ */
+export const TimeControl02 = (props: TimeControl02Props) => {
+  const { actorIds } = props
+
+  const [store] = useState(() => createActorStore())
+
+  return (
+    <ActorStoreContext.Provider value={store}>
+      <ActionBar actorIds={actorIds} />
+      <div className="flex gap-4">
+        <StageView actorIds={actorIds} />
+        <ul className="ui-container">
+          {actorIds.map((id) => (
+            <ActorItem id={id} key={id} />
+          ))}
+        </ul>
+      </div>
+      <div className="flex gap-4">
+        <div className="flex-1">
+          <p className="text-gray-400">
+            予定 (行動決定前のスケジュールプレビュー)
+          </p>
+          <SchedulePreview actorIds={actorIds} />
+        </div>
+        <div className="flex-1">
+          <p className="text-gray-400">履歴</p>
+          <ActionLogPanel actorIds={actorIds} />
+        </div>
+      </div>
+    </ActorStoreContext.Provider>
+  )
+}

--- a/src/prototypes/time-control/time-control-02/types.ts
+++ b/src/prototypes/time-control/time-control-02/types.ts
@@ -1,0 +1,102 @@
+export type ActorId = string
+
+/**
+ * 自由座標
+ *
+ * - 制限・クランプなし
+ */
+export type Position = {
+  /** X座標 */
+  x: number
+  /** Y座標 */
+  y: number
+}
+
+/**
+ * action-phase.md の5段階
+ *
+ * - 今回は intent/resolution のみ実際に発火する
+ */
+export type ActionPhase =
+  | 'execution'
+  | 'intent'
+  | 'outcome'
+  | 'pre-action'
+  | 'resolution'
+
+/** 段階ごとの所要時間 */
+export type ActionTiming = {
+  /** この段階の遷移に要する時間 (ms) */
+  durationMs: number
+  /** 対象の段階 */
+  phase: ActionPhase
+}
+
+/** 移動企図イベント */
+export type MoveIntent = {
+  /** 移動対象の actor */
+  actorId: ActorId
+  /** 移動先座標 */
+  target: Position
+}
+
+/** 経路上の1点 */
+export type PathStep = Position
+
+/** tick ごとに分割した移動経路 */
+export type MovePath = PathStep[]
+
+/** 行動の進行モード */
+export type ProgressMode = 'auto' | 'manual'
+
+/** マージ済みスケジュールの1行 */
+export type ScheduleRow = {
+  /** この時刻に行動する actor 一覧 */
+  actorIds: ActorId[]
+  /** 経過時間 (ms) */
+  timeMs: number
+}
+
+/** マージ済み履歴の1行 */
+export type HistoryRow = {
+  /** この時刻に発生した actor ごとのエントリ */
+  entryByActorId: Partial<Record<ActorId, ActionLogEntry>>
+  /** ゲーム内経過時間 (ms) */
+  gameTimeMs: number
+}
+
+/** 履歴の1エントリ */
+export type ActionLogEntry = {
+  /** 発生元 actor */
+  actorId: ActorId
+  /**
+   * ゲーム内経過時間 (ms、tick 単位の決定論的な値)
+   *
+   * - `TimeEvent.time` (実時刻) とは別物。実行タイミングの揺らぎに影響されず\
+   *   常に tickMs の倍数になる
+   */
+  gameTimeMs: number
+  /** 発生した段階 */
+  phase: ActionPhase
+  /** 関連する座標 */
+  target: Position
+}
+
+/**
+ * 時間管理の基本単位
+ *
+ * - 時刻付きイベントログの1エントリ
+ */
+export type TimeEvent<TEvent> = {
+  /** イベント本体 */
+  event: TEvent
+  /** イベント発生時刻 (epoch ms) */
+  time: number
+}
+
+/**
+ * 時刻付きイベントログ本体
+ *
+ * - 持ち越し型 (処理後も破棄しない)
+ */
+export type EventLog<TEvent> = TimeEvent<TEvent>[]


### PR DESCRIPTION
## Summary
- 複数 actor (A/B/C) の移動を 企図(Intent) → 実行(Execution, tick刻み) → 事後(Resolution) の3段階で管理する zustand vanilla store プロトタイプを追加 (`time-control-02`)
- 行動決定前のスケジュールプレビュー (`SchedulePreview`) と、実行済みログ (`ActionLogPanel`) を分離して表示
- speed / tickRate を分離し、tick 刻みで経路を消化する仕組みを実装

## 既知の課題 (03 で対応予定)
- `actionLog` の `gameTimeMs` が actor ごと独立した `tickCountById` 由来のため、実行順序と無関係に小さい値になり得る。結果、複数 actor が断続的に行動決定した場合、履歴テーブル上の行順序が実際の決定順と食い違い「詰めて」表示されることがある
- 根本対応として、actor 個別状態 (position/path/tick/mode) と log 管理 (actionLog・共通ゲームクロック) を store レベルで分離する設計を次プロトタイプ (03) で進める
- 検討メモ: `.claude/.steering/20260727-time-control-02-next-steps/design.md`

## Test plan
- [x] `npm run test` (Vitest) 通過確認
- [x] Storybook (`time-control-02` ストーリー) で A/B/C の set target → 行動決定 → 履歴表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)