### PR TITLE
refactor: Context の必須Provider throw を共通部品化

### DIFF
--- a/src/prototypes/time-control/time-control-03/_contexts/stage-transform-context.tsx
+++ b/src/prototypes/time-control/time-control-03/_contexts/stage-transform-context.tsx
@@ -1,12 +1,22 @@
-import { createContext, ReactNode, useContext, useMemo } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
+
+import { createRequiredContext } from '@/utils/create-required-context'
 
 import { computeFitTransform, StageTransform } from '../_lib/stage-coords'
 import { usePlannedPathStore } from '../_stores/planned-path'
 import { DEFAULT_POSITION } from '../_stores/position/constants'
 import { ActorId } from '../types'
 
-const StageTransformContext = createContext<null | StageTransform>(null)
+const { Context: StageTransformContext, useContextValue: useStageTransform } =
+  createRequiredContext<StageTransform>(
+    'useStageTransform should be used within <StageTransformProvider>',
+  )
+
+export {
+  /** 現在の stage transform を取得する */
+  useStageTransform,
+}
 
 type StageTransformProviderProps = {
   /** transform 算出対象の actor 一覧 */
@@ -45,17 +55,4 @@ export const StageTransformProvider = (props: StageTransformProviderProps) => {
       {children}
     </StageTransformContext.Provider>
   )
-}
-
-/** 現在の stage transform を取得する */
-export const useStageTransform = (): StageTransform => {
-  const transform = useContext(StageTransformContext)
-
-  if (transform === null) {
-    throw new Error(
-      'useStageTransform should be used within <StageTransformProvider>',
-    )
-  }
-
-  return transform
 }

--- a/src/stores/utils/create-store-context.ts
+++ b/src/stores/utils/create-store-context.ts
@@ -1,6 +1,7 @@
-import { createContext, useContext } from 'react'
 import { useStore } from 'zustand'
 import { StoreApi } from 'zustand/vanilla'
+
+import { createRequiredContext } from '@/utils/create-required-context'
 
 /**
  * store 用 Context 一式を生成する
@@ -14,19 +15,10 @@ import { StoreApi } from 'zustand/vanilla'
  * @param storeName store 名 (例: `ActorSettings`)。エラーメッセージの hook 名・Context 名生成に使う
  */
 export const createStoreContext = <State>(storeName: string) => {
-  const StoreContext = createContext<null | StoreApi<State>>(null)
-
-  const useStoreApi = (): StoreApi<State> => {
-    const store = useContext(StoreContext)
-
-    if (store === null) {
-      throw new Error(
-        `use${storeName}Store should be used within <${storeName}StoreContext.Provider>`,
-      )
-    }
-
-    return store
-  }
+  const { Context: StoreContext, useContextValue: useStoreApi } =
+    createRequiredContext<StoreApi<State>>(
+      `use${storeName}Store should be used within <${storeName}StoreContext.Provider>`,
+    )
 
   /**
    * @param selector 購読する state の一部を取り出す関数

--- a/src/utils/create-required-context.ts
+++ b/src/utils/create-required-context.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * 必須 Provider 前提の Context 一式を生成する
+ *
+ * - Context 生成 → 未 Provider 時 throw → 値取得、の定型実装をまとめる
+ *
+ * @param errorMessage 未 Provider 時に throw するエラーメッセージ
+ */
+export const createRequiredContext = <Value>(errorMessage: string) => {
+  const Context = createContext<null | Value>(null)
+
+  const useContextValue = (): Value => {
+    const value = useContext(Context)
+
+    if (value === null) {
+      throw new Error(errorMessage)
+    }
+
+    return value
+  }
+
+  return { Context, useContextValue }
+}


### PR DESCRIPTION
## Summary
- Context 生成 → 未 Provider 時 throw → 値取得、の定型実装を `createRequiredContext` として汎用部品化 (`src/utils/`)
- `createStoreContext` (zustand store 用) を `createRequiredContext` 利用に再構成
- `time-control-03` の `StageTransformContext` (非 store 系 context) も同部品に移行

## Test plan
- [x] `tsc --noEmit` pass
- [x] `eslint` pass