### PR TITLE
#50 refactor: stage-view 専用マーカーを _components 配下へ移動

### DIFF
--- a/.claude/rules/react/component-nesting.md
+++ b/.claude/rules/react/component-nesting.md
@@ -1,0 +1,30 @@
+# コンポーネント配置
+
+`_components/` 配下、特定の親コンポーネントからのみ使用する子コンポーネントは、親と同列に置かず親配下の `_components/` へ配置する。
+
+## 判断基準
+
+- 複数の親から参照される、またはページ直下(`index.tsx`)から直接使用される → 同列 `_components/`
+- 特定の1コンポーネント配下でのみ使用される → そのコンポーネント配下の `_components/`
+
+## 例
+
+`stage-view` 配下でのみ使う `planned-path-marker` `current-position-marker` は、`stage-view/_components/` へ配置する。
+
+```
+_components/
+  action-bar/
+  stage-view/
+    index.tsx
+    _components/
+      planned-path-marker/
+        index.tsx
+      current-position-marker/
+        index.tsx
+```
+
+`action-bar` は `index.tsx` から直接使用されるため同列のまま。
+
+## 既存構成の見直し
+
+新規追加時に限らず、実装が進み子コンポーネントの使用元が特定の親1つに絞られたと判明した時点でリファクタ対象とする。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ export const reducePointerState = (
 ### React
 
 @.claude/rules/react/hooks.md
+@.claude/rules/react/component-nesting.md
 
 ### ディレクトリ構成
 

--- a/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/index.tsx
@@ -1,10 +1,10 @@
 import { memo, useEffect, useRef } from 'react'
 
-import { getTickMs } from '../../../time-control-02/_lib/get-tick-ms'
-import { useStageTransform } from '../../_contexts/stage-transform-context'
-import { toPixelStyle } from '../../_lib/stage-coords'
-import { useActorStore, usePositionStoreApi } from '../../_stores'
-import { ActorId, Position } from '../../types'
+import { getTickMs } from '../../../../../time-control-02/_lib/get-tick-ms'
+import { useStageTransform } from '../../../../_contexts/stage-transform-context'
+import { toPixelStyle } from '../../../../_lib/stage-coords'
+import { useActorStore, usePositionStoreApi } from '../../../../_stores'
+import { ActorId, Position } from '../../../../types'
 
 type CurrentPositionMarkerProps = {
   /** 表示対象の actor */

--- a/src/prototypes/time-control/time-control-03/_components/stage-view/_components/planned-path-marker/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/stage-view/_components/planned-path-marker/index.tsx
@@ -1,9 +1,9 @@
 import { memo } from 'react'
 
-import { useStageTransform } from '../../_contexts/stage-transform-context'
-import { toPixelStyle } from '../../_lib/stage-coords'
-import { usePlannedPathStore } from '../../_stores'
-import { ActorId } from '../../types'
+import { useStageTransform } from '../../../../_contexts/stage-transform-context'
+import { toPixelStyle } from '../../../../_lib/stage-coords'
+import { usePlannedPathStore } from '../../../../_stores'
+import { ActorId } from '../../../../types'
 
 type PlannedPathMarkerProps = {
   /** 表示対象の actor */

--- a/src/prototypes/time-control/time-control-03/_components/stage-view/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/stage-view/index.tsx
@@ -1,8 +1,9 @@
 import { StageTransformProvider } from '../../_contexts/stage-transform-context'
 import { STAGE_SIZE } from '../../_lib/stage-coords'
 import { ActorId } from '../../types'
-import { CurrentPositionMarker } from '../current-position-marker'
-import { PlannedPathMarker } from '../planned-path-marker'
+
+import { CurrentPositionMarker } from './_components/current-position-marker'
+import { PlannedPathMarker } from './_components/planned-path-marker'
 
 type StageViewProps = {
   /** 表示する actor の一覧 */


### PR DESCRIPTION
## Summary
- `current-position-marker` / `planned-path-marker` は `stage-view` からのみ使用されているため、親と同列だった構成を `stage-view/_components` 配下へ移動
- 特定の親からのみ使う子コンポーネントを同列に置かないルールを新設し、`.claude/rules/react/component-nesting.md` として明文化

## Test plan
- [x] `tsc --noEmit` 通過確認
- [x] `eslint` 通過確認