### PR TITLE
#50 refactor: ActionBar/ActorController/CurrentPositionMarker のロジックを hooks へ分離

### DIFF
--- a/.claude/rules/react/hooks.md
+++ b/.claude/rules/react/hooks.md
@@ -8,6 +8,23 @@
 - 配置先: `.hooks` サフィックスファイル、または `_hooks/` ディレクトリ
 - 戻り値の名前: `use` 除いた部分 基本的に使用する。ライブラリ等で公式の使用法がある場合はそちらに合わせる
 
+### 構成分割 (index.tsx / index.hooks.ts / index.types.ts)
+
+ロジック規模大きいコンポーネント、下記構成へ分割する。
+
+```
+component-name/
+  index.tsx        # JSX のみ。ロジックは index.hooks.ts の use<ComponentName> 呼出すだけ
+  index.hooks.ts    # ベース hook use<ComponentName>。_hooks/ 配下の部品 hook 組合せるだけ
+  index.types.ts    # <ComponentName>Props, Use<ComponentName>Return 定義
+  _hooks/
+    use-xxx.ts       # 関心事ごとの部品 hook。1 hook = 1 ファイル、kebab-case
+```
+
+- ベース hook 名: コンポーネント名に `use` 付与(`ActionBar` → `useActionBar`)
+- 部品 hook の引数: コンポーネント props そのまま渡す(個別プロパティへ分解しない)
+- 部品 hook の戻り値型: 個別定義せず、`index.types.ts` の `Use<ComponentName>Return` から `Pick` で抽出する。型の出所を一元化する
+
 ## useEffect
 
 - ラインコメントで処理内容 簡潔に記述する

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-dispatch-decision.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-dispatch-decision.ts
@@ -1,0 +1,21 @@
+import { usePositionStore } from '../../../_stores'
+import { ActionBarProps, UseActionBarReturn } from '../index.types'
+
+/**
+ * 対象 actor 一括の行動決定実行
+ *
+ * @param props ActionBar に渡される props
+ */
+export const useDispatchDecision = (
+  props: ActionBarProps,
+): Pick<UseActionBarReturn, 'dispatchDecision'> => {
+  const { actorIds } = props
+
+  const dispatchActions = usePositionStore((state) => state.dispatchActions)
+
+  const dispatchDecision = () => {
+    dispatchActions(actorIds)
+  }
+
+  return { dispatchDecision }
+}

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-progress-mode.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-progress-mode.ts
@@ -1,0 +1,30 @@
+import { useActorSettingsStore } from '../../../_stores'
+import { ActionBarProps, UseActionBarReturn } from '../index.types'
+
+/**
+ * 進行モード(auto/manual)取得・全 actor 一括切替
+ *
+ * @param props ActionBar に渡される props
+ */
+export const useProgressMode = (
+  props: ActionBarProps,
+): Pick<UseActionBarReturn, 'progressMode' | 'toggleProgressMode'> => {
+  const { actorIds } = props
+
+  // 全 actor 常に同一 mode 前提の代表値取得。
+  // actor 毎 個別 mode 持たせる要件が復活したら要見直し(toggleProgressMode の forEach 一括更新も同様)
+  // * あるいは progressMode を統一してそれを保持する store を新設
+  const progressMode = useActorSettingsStore(
+    (state) => state.getActorSettings(actorIds[0]).progressMode,
+  )
+  const setProgressMode = useActorSettingsStore(
+    (state) => state.setProgressMode,
+  )
+
+  const toggleProgressMode = () => {
+    const nextMode = progressMode === 'auto' ? 'manual' : 'auto'
+    actorIds.forEach((id) => setProgressMode(id, nextMode))
+  }
+
+  return { progressMode, toggleProgressMode }
+}

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-reset-all.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-reset-all.ts
@@ -1,0 +1,32 @@
+import {
+  useActorSettingsStore,
+  useActorStore,
+  useGameClockStore,
+  usePathStore,
+  usePlannedPathStore,
+  usePositionStore,
+} from '../../../_stores'
+import { UseActionBarReturn } from '../index.types'
+
+/**
+ * 全 store (状態を持たない intent-store 以外) を初期状態に戻す
+ */
+export const useResetAll = (): Pick<UseActionBarReturn, 'resetAll'> => {
+  const resetActorSettings = useActorSettingsStore((state) => state.reset)
+  const resetPosition = usePositionStore((state) => state.reset)
+  const resetActor = useActorStore((state) => state.reset)
+  const resetPath = usePathStore((state) => state.reset)
+  const resetPlannedPath = usePlannedPathStore((state) => state.reset)
+  const resetGameClock = useGameClockStore((state) => state.reset)
+
+  const resetAll = () => {
+    resetActor()
+    resetActorSettings()
+    resetPath()
+    resetPlannedPath()
+    resetPosition()
+    resetGameClock()
+  }
+
+  return { resetAll }
+}

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/index.hooks.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/index.hooks.ts
@@ -1,0 +1,17 @@
+import { useDispatchDecision } from './_hooks/use-dispatch-decision'
+import { useProgressMode } from './_hooks/use-progress-mode'
+import { useResetAll } from './_hooks/use-reset-all'
+import { ActionBarProps, UseActionBarReturn } from './index.types'
+
+/**
+ * ActionBar の操作ロジック
+ *
+ * @param props ActionBar に渡される props
+ */
+export const useActionBar = (props: ActionBarProps): UseActionBarReturn => {
+  const { progressMode, toggleProgressMode } = useProgressMode(props)
+  const { dispatchDecision } = useDispatchDecision(props)
+  const { resetAll } = useResetAll()
+
+  return { dispatchDecision, progressMode, resetAll, toggleProgressMode }
+}

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/index.tsx
@@ -1,19 +1,7 @@
 import { Button } from '@/components/ui/button'
 
-import {
-  useActorSettingsStore,
-  useActorStore,
-  useGameClockStore,
-  usePathStore,
-  usePlannedPathStore,
-  usePositionStore,
-} from '../../_stores'
-import { ActorId } from '../../types'
-
-type ActionBarProps = {
-  /** 操作対象の actor 一覧 */
-  actorIds: ActorId[]
-}
+import { useActionBar } from './index.hooks'
+import { ActionBarProps } from './index.types'
 
 /**
  * 全 actor 一括の操作パネル
@@ -24,54 +12,18 @@ type ActionBarProps = {
  * - reset: 全 store (状態を持たない intent-store 以外) を初期状態に戻す
  */
 export const ActionBar = (props: ActionBarProps) => {
-  const { actorIds } = props
-
-  const progressMode = useActorSettingsStore(
-    (state) => state.getActorSettings(actorIds[0]).progressMode,
-  )
-  const setProgressMode = useActorSettingsStore(
-    (state) => state.setProgressMode,
-  )
-  const resetActorSettings = useActorSettingsStore((state) => state.reset)
-  const dispatchActions = usePositionStore((state) => state.dispatchActions)
-  const resetPosition = usePositionStore((state) => state.reset)
-  const resetActor = useActorStore((state) => state.reset)
-  const resetPath = usePathStore((state) => state.reset)
-  const resetPlannedPath = usePlannedPathStore((state) => state.reset)
-  const resetGameClock = useGameClockStore((state) => state.reset)
+  const { dispatchDecision, progressMode, resetAll, toggleProgressMode } =
+    useActionBar(props)
 
   return (
     <div className="flex gap-2 p-2">
-      <Button
-        onClick={() => {
-          dispatchActions(actorIds)
-        }}
-        type="button"
-      >
+      <Button onClick={dispatchDecision} type="button">
         行動決定
       </Button>
-      <Button
-        onClick={() => {
-          const nextMode = progressMode === 'auto' ? 'manual' : 'auto'
-          actorIds.forEach((id) => setProgressMode(id, nextMode))
-        }}
-        type="button"
-        variant="outline"
-      >
+      <Button onClick={toggleProgressMode} type="button" variant="outline">
         mode: {progressMode}
       </Button>
-      <Button
-        onClick={() => {
-          resetActor()
-          resetActorSettings()
-          resetPath()
-          resetPlannedPath()
-          resetPosition()
-          resetGameClock()
-        }}
-        type="button"
-        variant="destructive"
-      >
+      <Button onClick={resetAll} type="button" variant="destructive">
         reset
       </Button>
     </div>

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/index.types.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/index.types.ts
@@ -1,0 +1,17 @@
+import { ActorId, ProgressMode } from '../../types'
+
+export type ActionBarProps = {
+  /** 操作対象の actor 一覧 */
+  actorIds: ActorId[]
+}
+
+export type UseActionBarReturn = {
+  /** 行動決定実行 */
+  dispatchDecision: () => void
+  /** 進行モード (auto/manual) */
+  progressMode: ProgressMode
+  /** 全 store reset */
+  resetAll: () => void
+  /** 進行モード全 actor 一括切替 */
+  toggleProgressMode: () => void
+}

--- a/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-fixed-path-setting.ts
+++ b/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-fixed-path-setting.ts
@@ -1,0 +1,47 @@
+import { useActorSettingsStore } from '../../../_stores'
+import { ActorControllerProps, UseActorControllerReturn } from '../index.types'
+
+/**
+ * actor の固定 step 数取得・設定
+ *
+ * @param props ActorController に渡される props
+ */
+export const useFixedPathSetting = (
+  props: ActorControllerProps,
+): Pick<
+  UseActorControllerReturn,
+  | 'fixedPathSteps'
+  | 'isFixedPathSteps'
+  | 'setFixedPathSteps'
+  | 'setIsFixedPathSteps'
+> => {
+  const { id } = props
+
+  const fixedPathSteps = useActorSettingsStore(
+    (state) => state.getActorSettings(id).fixedPathSteps,
+  )
+  const isFixedPathSteps = useActorSettingsStore(
+    (state) => state.getActorSettings(id).isFixedPathSteps,
+  )
+  const setFixedPathStepsStore = useActorSettingsStore(
+    (state) => state.setFixedPathSteps,
+  )
+  const setIsFixedPathStepsStore = useActorSettingsStore(
+    (state) => state.setIsFixedPathSteps,
+  )
+
+  const setFixedPathSteps = (steps: number) => {
+    setFixedPathStepsStore(id, steps)
+  }
+
+  const setIsFixedPathSteps = (checked: boolean) => {
+    setIsFixedPathStepsStore(id, checked)
+  }
+
+  return {
+    fixedPathSteps,
+    isFixedPathSteps,
+    setFixedPathSteps,
+    setIsFixedPathSteps,
+  }
+}

--- a/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-position-info.ts
+++ b/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-position-info.ts
@@ -1,0 +1,19 @@
+import { usePathStore, usePositionStore } from '../../../_stores'
+import { ActorControllerProps, UseActorControllerReturn } from '../index.types'
+
+/**
+ * actor の現在位置・残り経路・企図取得
+ *
+ * @param props ActorController に渡される props
+ */
+export const usePositionInfo = (
+  props: ActorControllerProps,
+): Pick<UseActorControllerReturn, 'intentTarget' | 'path' | 'position'> => {
+  const { id } = props
+
+  const position = usePositionStore((state) => state.getPosition(id))
+  const path = usePathStore((state) => state.getPath(id))
+  const intentTarget = path[path.length - 1]
+
+  return { intentTarget, path, position }
+}

--- a/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-target-dispatch.ts
+++ b/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-target-dispatch.ts
@@ -1,0 +1,28 @@
+import { useIntentStore, usePositionStore } from '../../../_stores'
+import { ActorControllerProps, UseActorControllerReturn } from '../index.types'
+
+/**
+ * actor の target 企図実行 (現在位置からランダムオフセット)
+ *
+ * @param props ActorController に渡される props
+ */
+export const useTargetDispatch = (
+  props: ActorControllerProps,
+): Pick<UseActorControllerReturn, 'dispatchTarget'> => {
+  const { id } = props
+
+  const position = usePositionStore((state) => state.getPosition(id))
+  const dispatchMoveIntent = useIntentStore((state) => state.dispatchMoveIntent)
+
+  const dispatchTarget = () => {
+    dispatchMoveIntent({
+      actorId: id,
+      target: {
+        x: position.x + Math.round(Math.random() * 6 - 3),
+        y: position.y + Math.round(Math.random() * 6 - 3),
+      },
+    })
+  }
+
+  return { dispatchTarget }
+}

--- a/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-tick-setting.ts
+++ b/src/prototypes/time-control/time-control-03/_components/actor-controller/_hooks/use-tick-setting.ts
@@ -1,0 +1,30 @@
+import { getTickMs } from '../../../../time-control-02/_lib/get-tick-ms'
+import { useActorStore } from '../../../_stores'
+import { ActorControllerProps, UseActorControllerReturn } from '../index.types'
+
+/** tick 選択肢 (50ms 刻み、50〜500ms) */
+export const TICK_MS_OPTIONS = Array.from(
+  { length: 10 },
+  (_, index) => (index + 1) * 50,
+)
+
+/**
+ * actor の tick 時間取得・設定
+ *
+ * @param props ActorController に渡される props
+ */
+export const useTickSetting = (
+  props: ActorControllerProps,
+): Pick<UseActorControllerReturn, 'setTickMsOption' | 'tickMs'> => {
+  const { id } = props
+
+  const tickRate = useActorStore((state) => state.getActorInfo(id).tickRate)
+  const tickMs = getTickMs(tickRate)
+  const setTickMs = useActorStore((state) => state.setTickMs)
+
+  const setTickMsOption = (value: number) => {
+    setTickMs(id, value)
+  }
+
+  return { setTickMsOption, tickMs }
+}

--- a/src/prototypes/time-control/time-control-03/_components/actor-controller/index.hooks.ts
+++ b/src/prototypes/time-control/time-control-03/_components/actor-controller/index.hooks.ts
@@ -1,0 +1,40 @@
+import { useFixedPathSetting } from './_hooks/use-fixed-path-setting'
+import { usePositionInfo } from './_hooks/use-position-info'
+import { useTargetDispatch } from './_hooks/use-target-dispatch'
+import { useTickSetting } from './_hooks/use-tick-setting'
+import { ActorControllerProps, UseActorControllerReturn } from './index.types'
+
+/**
+ * ActorController の操作ロジック
+ *
+ * @param props ActorController に渡される props
+ */
+export const useActorController = (
+  props: ActorControllerProps,
+): UseActorControllerReturn => {
+  const { intentTarget, path, position } = usePositionInfo(props)
+  const { setTickMsOption, tickMs } = useTickSetting(props)
+  const {
+    fixedPathSteps,
+    isFixedPathSteps,
+    setFixedPathSteps,
+    setIsFixedPathSteps,
+  } = useFixedPathSetting(props)
+  const { dispatchTarget } = useTargetDispatch(props)
+
+  const etaMs = path.length * tickMs
+
+  return {
+    dispatchTarget,
+    etaMs,
+    fixedPathSteps,
+    intentTarget,
+    isFixedPathSteps,
+    path,
+    position,
+    setFixedPathSteps,
+    setIsFixedPathSteps,
+    setTickMsOption,
+    tickMs,
+  }
+}

--- a/src/prototypes/time-control/time-control-03/_components/actor-controller/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/actor-controller/index.tsx
@@ -3,26 +3,10 @@ import { memo } from 'react'
 import { Button } from '@/components/ui/button'
 
 import { formatCoord } from '../../../time-control-02/_lib/format-coord'
-import { getTickMs } from '../../../time-control-02/_lib/get-tick-ms'
-import {
-  useActorSettingsStore,
-  useActorStore,
-  useIntentStore,
-  usePathStore,
-  usePositionStore,
-} from '../../_stores'
-import { ActorId } from '../../types'
 
-type ActorControllerProps = {
-  /** 表示対象の actor */
-  id: ActorId
-}
-
-/** tick 選択肢 (50ms 刻み、50〜500ms) */
-const TICK_MS_OPTIONS = Array.from(
-  { length: 10 },
-  (_, index) => (index + 1) * 50,
-)
+import { TICK_MS_OPTIONS } from './_hooks/use-tick-setting'
+import { useActorController } from './index.hooks'
+import { ActorControllerProps } from './index.types'
 
 /**
  * actor 1体分の操作コントローラー
@@ -37,26 +21,19 @@ const TICK_MS_OPTIONS = Array.from(
 export const ActorController = memo((props: ActorControllerProps) => {
   const { id } = props
 
-  const position = usePositionStore((state) => state.getPosition(id))
-  const path = usePathStore((state) => state.getPath(id))
-  const tickRate = useActorStore((state) => state.getActorInfo(id).tickRate)
-  const fixedPathSteps = useActorSettingsStore(
-    (state) => state.getActorSettings(id).fixedPathSteps,
-  )
-  const isFixedPathSteps = useActorSettingsStore(
-    (state) => state.getActorSettings(id).isFixedPathSteps,
-  )
-  const intentTarget = path[path.length - 1]
-  const tickMs = getTickMs(tickRate)
-  const etaMs = path.length * tickMs
-  const dispatchMoveIntent = useIntentStore((state) => state.dispatchMoveIntent)
-  const setFixedPathSteps = useActorSettingsStore(
-    (state) => state.setFixedPathSteps,
-  )
-  const setIsFixedPathSteps = useActorSettingsStore(
-    (state) => state.setIsFixedPathSteps,
-  )
-  const setTickMs = useActorStore((state) => state.setTickMs)
+  const {
+    dispatchTarget,
+    etaMs,
+    fixedPathSteps,
+    intentTarget,
+    isFixedPathSteps,
+    path,
+    position,
+    setFixedPathSteps,
+    setIsFixedPathSteps,
+    setTickMsOption,
+    tickMs,
+  } = useActorController(props)
 
   return (
     <li className="flex items-center gap-2 whitespace-nowrap border-b border-solid border-gray-200 p-2">
@@ -70,7 +47,7 @@ export const ActorController = memo((props: ActorControllerProps) => {
         <select
           className="rounded border border-solid border-gray-300 px-1"
           onChange={(event) => {
-            setTickMs(id, Number(event.target.value))
+            setTickMsOption(Number(event.target.value))
           }}
           value={Math.round(tickMs)}
         >
@@ -87,7 +64,7 @@ export const ActorController = memo((props: ActorControllerProps) => {
         <input
           checked={isFixedPathSteps}
           onChange={(event) => {
-            setIsFixedPathSteps(id, event.target.checked)
+            setIsFixedPathSteps(event.target.checked)
           }}
           type="checkbox"
         />
@@ -101,25 +78,13 @@ export const ActorController = memo((props: ActorControllerProps) => {
             // 厳密な下限チェックは使用時 (dispatchMoveIntent) 側で行う。\
             // ここで弾くと controlled input の value が古い値に押し戻され、\
             // 入力中の値が消えて事実上編集不能になる
-            setFixedPathSteps(id, Number(event.target.value))
+            setFixedPathSteps(Number(event.target.value))
           }}
           type="number"
           value={fixedPathSteps}
         />
       </label>
-      <Button
-        onClick={() => {
-          dispatchMoveIntent({
-            actorId: id,
-            target: {
-              x: position.x + Math.round(Math.random() * 6 - 3),
-              y: position.y + Math.round(Math.random() * 6 - 3),
-            },
-          })
-        }}
-        size="sm"
-        type="button"
-      >
+      <Button onClick={dispatchTarget} size="sm" type="button">
         set target
       </Button>
       <span className="text-gray-400">

--- a/src/prototypes/time-control/time-control-03/_components/actor-controller/index.types.ts
+++ b/src/prototypes/time-control/time-control-03/_components/actor-controller/index.types.ts
@@ -1,0 +1,31 @@
+import { ActorId, Position } from '../../types'
+
+export type ActorControllerProps = {
+  /** 表示対象の actor */
+  id: ActorId
+}
+
+export type UseActorControllerReturn = {
+  /** target 企図実行 (現在位置からランダムオフセット) */
+  dispatchTarget: () => void
+  /** 到達までの残り時間 (ms) */
+  etaMs: number
+  /** 固定 step 数 */
+  fixedPathSteps: number
+  /** 現在の企図 (経路の最終要素、経路が空なら企図なし/到達済み) */
+  intentTarget: Position | undefined
+  /** 固定 step 有効か */
+  isFixedPathSteps: boolean
+  /** 残り経路 */
+  path: Position[]
+  /** 現在位置 */
+  position: Position
+  /** 固定 step 数設定 */
+  setFixedPathSteps: (steps: number) => void
+  /** 固定 step 有効切替 */
+  setIsFixedPathSteps: (checked: boolean) => void
+  /** tick 時間設定 */
+  setTickMsOption: (value: number) => void
+  /** tick 時間 (ms) */
+  tickMs: number
+}

--- a/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/_hooks/use-effect-apply-position.ts
+++ b/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/_hooks/use-effect-apply-position.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react'
+
+import { getTickMs } from '../../../../../../time-control-02/_lib/get-tick-ms'
+import { useStageTransform } from '../../../../../_contexts/stage-transform-context'
+import { toPixelStyle } from '../../../../../_lib/stage-coords'
+import { useActorStore, usePositionStoreApi } from '../../../../../_stores'
+import { Position } from '../../../../../types'
+import { CurrentPositionMarkerProps } from '../index.types'
+
+/**
+ * position store 購読、DOM の style 直接書換で位置反映
+ *
+ * - React の再レンダリングを経由しないため、行動決定による position 更新でも\
+ *   コンポーネント自体は再レンダリングされない
+ * - tick 間の移動は CSS transition (`transitionDuration` = tickMs) で補間する。\
+ *   初回表示のみ transition なしで即時配置する (0,0 からのスライドを防ぐ)
+ *
+ * @param props CurrentPositionMarker に渡される props
+ */
+export const useEffectApplyPosition = (props: CurrentPositionMarkerProps) => {
+  const { id } = props
+
+  const positionStoreApi = usePositionStoreApi()
+  const transform = useStageTransform()
+  const tickRate = useActorStore((state) => state.getActorInfo(id).tickRate)
+  const tickMs = getTickMs(tickRate)
+  const markerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const applyPosition = (position: Position, animate: boolean) => {
+      if (!markerRef.current) {
+        return
+      }
+
+      const { left, top } = toPixelStyle(position, transform)
+
+      markerRef.current.style.transitionDuration = animate
+        ? `${tickMs}ms`
+        : '0ms'
+      markerRef.current.style.left = `${left}px`
+      markerRef.current.style.top = `${top}px`
+    }
+
+    applyPosition(positionStoreApi.getState().getPosition(id), false)
+
+    return positionStoreApi.subscribe((state) =>
+      applyPosition(state.getPosition(id), true),
+    )
+  }, [id, positionStoreApi, tickMs, transform])
+
+  return markerRef
+}

--- a/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/index.tsx
@@ -1,58 +1,19 @@
-import { memo, useEffect, useRef } from 'react'
+import { memo } from 'react'
 
-import { getTickMs } from '../../../../../time-control-02/_lib/get-tick-ms'
-import { useStageTransform } from '../../../../_contexts/stage-transform-context'
-import { toPixelStyle } from '../../../../_lib/stage-coords'
-import { useActorStore, usePositionStoreApi } from '../../../../_stores'
-import { ActorId, Position } from '../../../../types'
-
-type CurrentPositionMarkerProps = {
-  /** 表示対象の actor */
-  id: ActorId
-}
+import { useEffectApplyPosition } from './_hooks/use-effect-apply-position'
+import { CurrentPositionMarkerProps } from './index.types'
 
 /**
  * actor 1体分の現在位置表示 (CSS 絶対位置)
  *
- * - `positionStore` を直接 subscribe し、position 変化時は ref 経由で DOM の style を\
- *   直接書き換える。React の再レンダリングを経由しないため、行動決定による\
- *   position 更新でもコンポーネント自体は再レンダリングされない
  * - `set target` (企図) は購読対象外のため影響しない\
  *   (`positionStore` は行動決定でのみ更新される)
- * - tick 間の移動は CSS transition (`transitionDuration` = tickMs) で補間する。\
- *   初回表示のみ transition なしで即時配置する (0,0 からのスライドを防ぐ)
  */
 export const CurrentPositionMarker = memo(
   (props: CurrentPositionMarkerProps) => {
     const { id } = props
 
-    const positionStoreApi = usePositionStoreApi()
-    const transform = useStageTransform()
-    const tickRate = useActorStore((state) => state.getActorInfo(id).tickRate)
-    const tickMs = getTickMs(tickRate)
-    const markerRef = useRef<HTMLDivElement>(null)
-
-    useEffect(() => {
-      const applyPosition = (position: Position, animate: boolean) => {
-        if (!markerRef.current) {
-          return
-        }
-
-        const { left, top } = toPixelStyle(position, transform)
-
-        markerRef.current.style.transitionDuration = animate
-          ? `${tickMs}ms`
-          : '0ms'
-        markerRef.current.style.left = `${left}px`
-        markerRef.current.style.top = `${top}px`
-      }
-
-      applyPosition(positionStoreApi.getState().getPosition(id), false)
-
-      return positionStoreApi.subscribe((state) =>
-        applyPosition(state.getPosition(id), true),
-      )
-    }, [id, positionStoreApi, tickMs, transform])
+    const markerRef = useEffectApplyPosition(props)
 
     return (
       <div

--- a/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/index.types.ts
+++ b/src/prototypes/time-control/time-control-03/_components/stage-view/_components/current-position-marker/index.types.ts
@@ -1,0 +1,6 @@
+import { ActorId } from '../../../../types'
+
+export type CurrentPositionMarkerProps = {
+  /** 表示対象の actor */
+  id: ActorId
+}


### PR DESCRIPTION
## Summary
- ActionBar / ActorController / CurrentPositionMarker のコンポーネント内ロジックをカスタムフックへ分離、コンポーネントを JSX 主体に整理
- `index.hooks.ts`(ベース hook) / `index.types.ts`(props・戻り値型) / `_hooks/`(関心事ごとの部品 hook) の3層構成を確立
- 部品 hook の戻り値型は個別定義せず `Use<ComponentName>Return` から `Pick` で抽出、型の出所を一元化
- CurrentPositionMarker は既存の useEffect カスタムフック化ルールに従い単一 hook で対応(フル3層構成は対象外と判断)
- 上記構成パターンを `.claude/rules/react/hooks.md` に明文化

## Test plan
- [x] `tsc --noEmit`
- [x] `eslint`
- [x] `vitest run` (time-control-03 配下 51 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)