### PR TITLE
#50 refactor: component 直下ロジックを store・既存機構へ一本化

### DIFF
--- a/src/prototypes/time-control/time-control-03/__tests__/actor-settings-store.test.ts
+++ b/src/prototypes/time-control/time-control-03/__tests__/actor-settings-store.test.ts
@@ -44,6 +44,16 @@ test('setProgressMode は対象 actor の progressMode のみ更新する', () =
   })
 })
 
+test('toggleProgressMode は対象 actor 全員の progressMode を一括反転する', () => {
+  const store = createActorSettingsStore()
+
+  store.getState().setProgressMode('a', 'manual')
+  store.getState().toggleProgressMode(['a', 'b'])
+
+  expect(store.getState().settingsById.a?.progressMode).toBe('auto')
+  expect(store.getState().settingsById.b?.progressMode).toBe('auto')
+})
+
 test('reset で全 actor の設定が初期状態に戻る', () => {
   const store = createActorSettingsStore()
 

--- a/src/prototypes/time-control/time-control-03/__tests__/game-clock-lib.test.ts
+++ b/src/prototypes/time-control/time-control-03/__tests__/game-clock-lib.test.ts
@@ -1,0 +1,41 @@
+import { buildHistory } from '../_stores/game-clock/lib'
+import { ActionLogEntry, EventLog } from '../types'
+
+const entry = (
+  actorId: string,
+  gameTimeMs: number,
+  phase: ActionLogEntry['phase'],
+): EventLog<ActionLogEntry>[number] => ({
+  event: { actorId, gameTimeMs, phase, target: { x: 0, y: 0 } },
+  time: Date.now(),
+})
+
+test('actionLog が空なら空配列を返す', () => {
+  expect(buildHistory(['a'], [])).toEqual([])
+})
+
+test('intent は除外される', () => {
+  const log = [entry('a', 0, 'intent'), entry('a', 100, 'execution')]
+
+  expect(buildHistory(['a'], log)).toEqual([
+    { entryByActorId: { a: log[1].event }, gameTimeMs: 100 },
+  ])
+})
+
+test('同一 gameTimeMs の複数 actor は1行にまとまる', () => {
+  const log = [
+    entry('a', 100, 'execution'),
+    entry('b', 100, 'execution'),
+    entry('a', 200, 'resolution'),
+  ]
+
+  const history = buildHistory(['a', 'b'], log)
+
+  expect(history).toEqual([
+    {
+      entryByActorId: { a: log[0].event, b: log[1].event },
+      gameTimeMs: 100,
+    },
+    { entryByActorId: { a: log[2].event }, gameTimeMs: 200 },
+  ])
+})

--- a/src/prototypes/time-control/time-control-03/__tests__/game-clock-store.test.ts
+++ b/src/prototypes/time-control/time-control-03/__tests__/game-clock-store.test.ts
@@ -83,6 +83,31 @@ test('同一 actor の tick は累積し、後退・重複しない', () => {
   expect(event2.gameTimeMs).toBe(200)
 })
 
+test('getHistory は eventLog を対象に履歴行を生成する', () => {
+  const store = createGameClockStore()
+
+  store
+    .getState()
+    .logEvent<ActionLogEntry>(
+      { actorId: 'a', phase: 'execution', target: { x: 1, y: 0 } },
+      100,
+    )
+
+  expect(store.getState().getHistory(['a'])).toEqual([
+    {
+      entryByActorId: {
+        a: {
+          actorId: 'a',
+          gameTimeMs: 100,
+          phase: 'execution',
+          target: { x: 1, y: 0 },
+        },
+      },
+      gameTimeMs: 100,
+    },
+  ])
+})
+
 test('reset で eventLog・commonGameTimeMs が初期状態に戻る', () => {
   const store = createGameClockStore()
 

--- a/src/prototypes/time-control/time-control-03/__tests__/planned-path-store.test.ts
+++ b/src/prototypes/time-control/time-control-03/__tests__/planned-path-store.test.ts
@@ -18,6 +18,20 @@ test('setPlannedPath は対象 actor の予定経路のみ置き換える', () =
   })
 })
 
+test('getTargets は対象 actor 全員の予定経路の終点を返す', () => {
+  const store = createPlannedPathStore()
+
+  store.getState().setPlannedPath('a', [
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+  ])
+
+  expect(store.getState().getTargets(['a', 'b'])).toEqual([
+    { x: 2, y: 0 },
+    { x: 0, y: 0 },
+  ])
+})
+
 test('reset で全 actor の予定経路が初期状態に戻る', () => {
   const store = createPlannedPathStore()
 

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_components/async-sample-button/index.hooks.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_components/async-sample-button/index.hooks.ts
@@ -1,18 +1,18 @@
-import { useState } from 'react'
-
-import { useTimeControl03EventDispatcher } from '../../../../_events'
+import {
+  useTimeControl03EventDispatcher,
+  useTimeControl03EventPending,
+} from '../../../../_events'
 
 /**
  * AsyncSampleButton の操作ロジック
  */
 export const useAsyncSampleButton = () => {
   const timeControl03EventDispatcher = useTimeControl03EventDispatcher()
-  const [isDispatching, setIsDispatching] = useState(false)
+  const { isPending: isDispatching } =
+    useTimeControl03EventPending('async-sample')
 
-  const dispatchAsyncSample = async () => {
-    setIsDispatching(true)
-    await timeControl03EventDispatcher['async-sample']()
-    setIsDispatching(false)
+  const dispatchAsyncSample = () => {
+    timeControl03EventDispatcher['async-sample']()
   }
 
   return { dispatchAsyncSample, isDispatching }

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-progress-mode.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-progress-mode.ts
@@ -12,19 +12,16 @@ export const useProgressMode = (): Pick<
   const { actorIds } = useTimeControl03Props()
 
   // 全 actor 常に同一 mode 前提の代表値取得。
-  // actor 毎 個別 mode 持たせる要件が復活したら要見直し(toggleProgressMode の forEach 一括更新も同様)
+  // actor 毎 個別 mode 持たせる要件が復活したら要見直し(store 側の toggleProgressMode 一括更新も同様)
   // * あるいは progressMode を統一してそれを保持する store を新設
   const progressMode = useActorSettingsStore(
     (state) => state.getActorSettings(actorIds[0]).progressMode,
   )
-  const setProgressMode = useActorSettingsStore(
-    (state) => state.setProgressMode,
+  const toggleProgressModeStore = useActorSettingsStore(
+    (state) => state.toggleProgressMode,
   )
 
-  const toggleProgressMode = () => {
-    const nextMode = progressMode === 'auto' ? 'manual' : 'auto'
-    actorIds.forEach((id) => setProgressMode(id, nextMode))
-  }
+  const toggleProgressMode = () => toggleProgressModeStore(actorIds)
 
   return { progressMode, toggleProgressMode }
 }

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-progress-mode.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_hooks/use-progress-mode.ts
@@ -17,6 +17,8 @@ export const useProgressMode = (): Pick<
   const progressMode = useActorSettingsStore(
     (state) => state.getActorSettings(actorIds[0]).progressMode,
   )
+
+  // TODO event-listener への移行
   const toggleProgressModeStore = useActorSettingsStore(
     (state) => state.toggleProgressMode,
   )

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/index.hooks.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/index.hooks.ts
@@ -1,5 +1,4 @@
 import { useTimeControl03EventDispatcher } from '../../_events'
-import { useTimeControl03Props } from '../../index.contexts'
 
 import { useProgressMode } from './_hooks/use-progress-mode'
 import { UseActionBarReturn } from './index.types'
@@ -8,14 +7,11 @@ import { UseActionBarReturn } from './index.types'
  * ActionBar の操作ロジック
  */
 export const useActionBar = (): UseActionBarReturn => {
-  const { actorIds } = useTimeControl03Props()
-
   const { progressMode, toggleProgressMode } = useProgressMode()
   const timeControl03EventDispatcher = useTimeControl03EventDispatcher()
 
-  const dispatchDecision = () => {
-    timeControl03EventDispatcher['dispatch-decision']({ actorIds })
-  }
+  const dispatchDecision: UseActionBarReturn['dispatchDecision'] =
+    timeControl03EventDispatcher['dispatch-decision']
 
   const resetAll: UseActionBarReturn['resetAll'] =
     timeControl03EventDispatcher['reset-all']

--- a/src/prototypes/time-control/time-control-03/_components/action-log-panel/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/action-log-panel/index.tsx
@@ -7,7 +7,6 @@ import {
   TableRow,
 } from '@/components/ui/table'
 
-import { buildHistory } from '../../../time-control-02/_lib/build-history'
 import { formatCoord } from '../../../time-control-02/_lib/format-coord'
 import { useGameClockStore } from '../../_stores'
 import { useTimeControl03Props } from '../../index.contexts'
@@ -22,9 +21,7 @@ import { useTimeControl03Props } from '../../index.contexts'
 export const ActionLogPanel = () => {
   const { actorIds } = useTimeControl03Props()
 
-  const eventLog = useGameClockStore((state) => state.eventLog)
-
-  const rows = buildHistory(actorIds, eventLog)
+  const historyRows = useGameClockStore((state) => state.getHistory(actorIds))
 
   return (
     <TableElement className="table-fixed">
@@ -37,7 +34,7 @@ export const ActionLogPanel = () => {
         </TableRow>
       </TableHeader>
       <TableBody>
-        {rows.map((row) => (
+        {historyRows.map((row) => (
           <TableRow key={row.gameTimeMs}>
             <TableCell className="whitespace-nowrap">
               {row.gameTimeMs}ms

--- a/src/prototypes/time-control/time-control-03/_components/schedule-preview/index.hooks.ts
+++ b/src/prototypes/time-control/time-control-03/_components/schedule-preview/index.hooks.ts
@@ -1,0 +1,26 @@
+import { buildSchedule } from '../../_lib/build-schedule'
+import { useActorStore, useGameClockStore, usePathStore } from '../../_stores'
+import { useTimeControl03Props } from '../../index.contexts'
+
+/**
+ * SchedulePreview の表示ロジック
+ *
+ * - 各 actor の残り経路 (`pathById`) から tick タイミングを共通ゲームクロック起点でマージし、\
+ *   同時刻の tick は1行にまとめたスケジュールを返す
+ */
+export const useSchedulePreview = () => {
+  const { actorIds } = useTimeControl03Props()
+
+  const pathById = usePathStore((state) => state.pathById)
+  const actorById = useActorStore((state) => state.actorById)
+  const commonGameTimeMs = useGameClockStore((state) => state.commonGameTimeMs)
+
+  const schedule = buildSchedule(
+    actorIds,
+    pathById,
+    actorById,
+    commonGameTimeMs,
+  )
+
+  return { actorIds, schedule }
+}

--- a/src/prototypes/time-control/time-control-03/_components/schedule-preview/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/schedule-preview/index.tsx
@@ -9,9 +9,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 
-import { buildSchedule } from '../../_lib/build-schedule'
-import { useActorStore, useGameClockStore, usePathStore } from '../../_stores'
-import { useTimeControl03Props } from '../../index.contexts'
+import { useSchedulePreview } from './index.hooks'
 
 type ScheduleCellProps = {
   /** この行 (tick) で行動があるか */
@@ -43,18 +41,7 @@ ScheduleCell.displayName = 'ScheduleCell'
  *   (同一行に複数 actor が並ぶ場合、経過時間を列ごとに重複表示しないため)
  */
 export const SchedulePreview = () => {
-  const { actorIds } = useTimeControl03Props()
-
-  const pathById = usePathStore((state) => state.pathById)
-  const actorById = useActorStore((state) => state.actorById)
-  const commonGameTimeMs = useGameClockStore((state) => state.commonGameTimeMs)
-
-  const schedule = buildSchedule(
-    actorIds,
-    pathById,
-    actorById,
-    commonGameTimeMs,
-  )
+  const { actorIds, schedule } = useSchedulePreview()
 
   return (
     <TableElement className="table-fixed">

--- a/src/prototypes/time-control/time-control-03/_contexts/stage-transform-context.tsx
+++ b/src/prototypes/time-control/time-control-03/_contexts/stage-transform-context.tsx
@@ -5,7 +5,6 @@ import { createRequiredContext } from '@/utils/create-required-context'
 
 import { computeFitTransform, StageTransform } from '../_lib/stage-coords'
 import { usePlannedPathStore } from '../_stores/planned-path'
-import { DEFAULT_POSITION } from '../_stores/position/constants'
 import { useTimeControl03Props } from '../index.contexts'
 
 const { Context: StageTransformContext, useContextValue: useStageTransform } =
@@ -37,13 +36,7 @@ export const StageTransformProvider = (props: StageTransformProviderProps) => {
   const { actorIds } = useTimeControl03Props()
 
   const targets = usePlannedPathStore(
-    useShallow((state) =>
-      actorIds.map((id) => {
-        const path = state.getPlannedPath(id)
-
-        return path[path.length - 1] ?? DEFAULT_POSITION
-      }),
-    ),
+    useShallow((state) => state.getTargets(actorIds)),
   )
   const transform = useMemo(() => computeFitTransform(targets), [targets])
 

--- a/src/prototypes/time-control/time-control-03/_events/_event-listeners/use-dispatch-decision-event-listener/index.ts
+++ b/src/prototypes/time-control/time-control-03/_events/_event-listeners/use-dispatch-decision-event-listener/index.ts
@@ -1,13 +1,15 @@
 import { usePositionStore } from '../../../_stores'
+import { useTimeControl03Props } from '../../../index.contexts'
 import { useTimeControl03EventListener } from '../../_hooks/use-time-control-03-event-listener'
 
 /**
  * dispatch-decision イベントを購読し、対象 actor 一括の行動決定を実行する
  */
 export const useDispatchDecisionEventListener = () => {
+  const { actorIds } = useTimeControl03Props()
   const dispatchActions = usePositionStore((state) => state.dispatchActions)
 
-  useTimeControl03EventListener('dispatch-decision', (event) => {
-    dispatchActions(event.detail.actorIds)
+  useTimeControl03EventListener('dispatch-decision', () => {
+    dispatchActions(actorIds)
   })
 }

--- a/src/prototypes/time-control/time-control-03/_events/index.types.ts
+++ b/src/prototypes/time-control/time-control-03/_events/index.types.ts
@@ -1,5 +1,3 @@
-import { ActorId } from '../types'
-
 /**
  * イベント名 → payload 型の対応表
  */
@@ -7,7 +5,7 @@ export type TimeControl03EventMap = {
   /** async listener 実演用サンプル (store 未使用、listener 内で Promise + setTimeout 完結) */
   'async-sample': undefined
   /** 対象 actor 一括の行動決定実行 */
-  'dispatch-decision': { actorIds: ActorId[] }
+  'dispatch-decision': undefined
   /** 全 store (状態を持たない intent-store 以外) を初期状態に戻す */
   'reset-all': undefined
 }

--- a/src/prototypes/time-control/time-control-03/_stores/actor-settings/store.ts
+++ b/src/prototypes/time-control/time-control-03/_stores/actor-settings/store.ts
@@ -48,4 +48,21 @@ export const createActorSettingsStore = (): ActorSettingsStore =>
         },
       }))
     },
+    toggleProgressMode: (actorIds) => {
+      const currentMode = get().getActorSettings(actorIds[0]).progressMode
+      const nextMode = currentMode === 'auto' ? 'manual' : 'auto'
+
+      set((state) => ({
+        settingsById: actorIds.reduce(
+          (settingsById, actorId) => ({
+            ...settingsById,
+            [actorId]: {
+              ...(state.settingsById[actorId] ?? DEFAULT_ACTOR_SETTINGS),
+              progressMode: nextMode,
+            },
+          }),
+          state.settingsById,
+        ),
+      }))
+    },
   }))

--- a/src/prototypes/time-control/time-control-03/_stores/actor-settings/types.ts
+++ b/src/prototypes/time-control/time-control-03/_stores/actor-settings/types.ts
@@ -30,6 +30,12 @@ export type ActorSettingsState = {
   setProgressMode: (actorId: ActorId, mode: ProgressMode) => void
   /** actor ごとの操作設定 */
   settingsById: Record<ActorId, ActorSettings>
+  /**
+   * 対象 actor 全員の行動進行モードを一括反転する
+   *
+   * - 現在値は先頭 actor の設定を代表値として判定する
+   */
+  toggleProgressMode: (actorIds: ActorId[]) => void
 }
 
 export type ActorSettingsStore = StoreApi<ActorSettingsState>

--- a/src/prototypes/time-control/time-control-03/_stores/game-clock/lib.ts
+++ b/src/prototypes/time-control/time-control-03/_stores/game-clock/lib.ts
@@ -1,0 +1,35 @@
+import { ActionLogEntry, ActorId, EventLog, HistoryRow } from '../../types'
+
+/**
+ * actionLog から、gameTimeMs でマージした履歴行を生成する
+ *
+ * - 同一 gameTimeMs の複数 actor は1行にまとめる (`buildSchedule` と同じ方針)
+ * - intent は対象外 (actor 行側で表示するため)
+ *
+ * @param actorIds 対象 actor 一覧
+ * @param actionLog 行動履歴
+ */
+export const buildHistory = (
+  actorIds: ActorId[],
+  actionLog: EventLog<ActionLogEntry>,
+): HistoryRow[] => {
+  const entryByActorIdByTime = new Map<
+    number,
+    Partial<Record<ActorId, ActionLogEntry>>
+  >()
+
+  for (const { event } of actionLog) {
+    if (event.phase === 'intent' || !actorIds.includes(event.actorId)) {
+      continue
+    }
+
+    const row = entryByActorIdByTime.get(event.gameTimeMs) ?? {}
+
+    row[event.actorId] = event
+    entryByActorIdByTime.set(event.gameTimeMs, row)
+  }
+
+  return [...entryByActorIdByTime.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([gameTimeMs, entryByActorId]) => ({ entryByActorId, gameTimeMs }))
+}

--- a/src/prototypes/time-control/time-control-03/_stores/game-clock/store.ts
+++ b/src/prototypes/time-control/time-control-03/_stores/game-clock/store.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'zustand/vanilla'
 
+import { buildHistory } from './lib'
 import { GameClockState, GameClockStore, GameEvent } from './types'
 
 const INITIAL_STATE = {
@@ -10,6 +11,7 @@ const INITIAL_STATE = {
 export const createGameClockStore = (): GameClockStore =>
   createStore<GameClockState>((set, get) => ({
     ...INITIAL_STATE,
+    getHistory: (actorIds) => buildHistory(actorIds, get().eventLog),
     logEvent: (<TEvent extends GameEvent>(
       payload: Omit<TEvent, 'gameTimeMs'>,
       advanceTickMs?: number,

--- a/src/prototypes/time-control/time-control-03/_stores/game-clock/types.ts
+++ b/src/prototypes/time-control/time-control-03/_stores/game-clock/types.ts
@@ -1,6 +1,6 @@
 import { StoreApi } from 'zustand/vanilla'
 
-import { ActionLogEntry, EventLog } from '../../types'
+import { ActionLogEntry, ActorId, EventLog, HistoryRow } from '../../types'
 
 /**
  * 共通ゲームクロックに乗るイベント種別の総称
@@ -15,6 +15,14 @@ export type GameClockState = {
   commonGameTimeMs: number
   /** 共通ゲームクロック由来の gameTimeMs を持つ、あらゆるイベントの時系列ログ */
   eventLog: EventLog<GameEvent>
+  /**
+   * eventLog から、gameTimeMs でマージした履歴行を生成する
+   *
+   * - 同一 gameTimeMs の複数 actor は1行にまとめる
+   *
+   * @param actorIds 対象 actor 一覧
+   */
+  getHistory: (actorIds: ActorId[]) => HistoryRow[]
   /**
    * イベントを記録する
    *

--- a/src/prototypes/time-control/time-control-03/_stores/planned-path/store.ts
+++ b/src/prototypes/time-control/time-control-03/_stores/planned-path/store.ts
@@ -1,5 +1,7 @@
 import { createStore } from 'zustand/vanilla'
 
+import { DEFAULT_POSITION } from '../position/constants'
+
 import { DEFAULT_PLANNED_PATH } from './constants'
 import { PlannedPathState, PlannedPathStore } from './types'
 
@@ -12,6 +14,12 @@ export const createPlannedPathStore = (): PlannedPathStore =>
     ...INITIAL_STATE,
     getPlannedPath: (actorId) =>
       get().plannedPathById[actorId] ?? DEFAULT_PLANNED_PATH,
+    getTargets: (actorIds) =>
+      actorIds.map((actorId) => {
+        const path = get().getPlannedPath(actorId)
+
+        return path[path.length - 1] ?? DEFAULT_POSITION
+      }),
     reset: () => {
       set(INITIAL_STATE)
     },

--- a/src/prototypes/time-control/time-control-03/_stores/planned-path/types.ts
+++ b/src/prototypes/time-control/time-control-03/_stores/planned-path/types.ts
@@ -1,6 +1,6 @@
 import { StoreApi } from 'zustand/vanilla'
 
-import { ActorId, MovePath } from '../../types'
+import { ActorId, MovePath, Position } from '../../types'
 
 /**
  * actor ごとの「予定位置」表示専用の経路を保持する store
@@ -12,6 +12,14 @@ import { ActorId, MovePath } from '../../types'
 export type PlannedPathState = {
   /** actor の予定経路を取得する (未設定時はデフォルト値を返す) */
   getPlannedPath: (actorId: ActorId) => MovePath
+  /**
+   * 対象 actor 全員の目標地点 (予定経路の終点) を取得する
+   *
+   * - 未企図 actor (予定経路が空) は `DEFAULT_POSITION` で補う
+   *
+   * @param actorIds 対象 actor 一覧
+   */
+  getTargets: (actorIds: ActorId[]) => Position[]
   /** actor ごとの予定経路 (表示専用) */
   plannedPathById: Record<ActorId, MovePath>
   /** 予定経路を初期状態に戻す */


### PR DESCRIPTION
## Summary

- `toggleProgressMode`(全 actor 一括切替)を `actor-settings` store の action として集約
- `buildHistory` を time-control-02 依存から `game-clock/lib.ts` へ移動、`getHistory` action 経由に一本化
- `dispatch-decision` イベントを `reset-all` と同じ「引数なし」パターンに統一(listener が props から直接 actorIds を読む)
- `SchedulePreview` の component 直書きロジックを `index.hooks.ts` へ分離(React 実装規約準拠)
- `StageTransformProvider` の target 算出ロジックを `planned-path` store の `getTargets` action へ移動
- `AsyncSampleButton` の `isDispatching` 自前 `useState` 管理を、既存の `useTimeControl03EventPending` (registry 経由 pending 監視)へ置換

いずれも「component 層が store 内部構造・複数 store の存在を知っている」状態を解消する、event-driven-decoupling steering の流れを汲むリファクタリング。

## Test plan

- [x] `npx tsc --noEmit -p .` 通過
- [x] `npx eslint` 通過 (対象ファイルすべて)
- [x] `NEXT_PUBLIC_API_URL=http://localhost:3000 npx vitest run src/prototypes/time-control/time-control-03` 全58件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)