### PR TITLE
#50 refactor: create~Context 系の命名・可読性改善

### DIFF
--- a/.claude/rules/react/hooks.md
+++ b/.claude/rules/react/hooks.md
@@ -29,3 +29,20 @@ component-name/
 
 - ラインコメントで処理内容 簡潔に記述する
 - カスタムフック化を優先する。フック名は `useEffect〜` とする
+
+## create~Context 系ユーティリティの再 export
+
+`createStoreContext`/`createPropsContext`/`createRequiredContext` 等の戻り値、`export const useX = useY` で直接代入 再 export しない。関数でラップして export する。
+
+- 理由: 直接代入だとエディタの定義ジャンプが utility 内部の実装へ飛び、各 store/context 側の宣言箇所に辿り着けない
+- selector 購読系、`Parameters<typeof useStoreSelector<T>>` で引数型を由来元から自動導出し、型定義の重複を避ける
+
+```ts
+// 悪い例
+export const usePositionStore = useStoreSelector
+
+// 良い例
+export const usePositionStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)
+```

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_components/progress-mode-button/index.hooks.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_components/progress-mode-button/index.hooks.ts
@@ -1,0 +1,18 @@
+import { useTimeControl03Computed } from '../../../../_computed'
+import { useTimeControl03EventDispatcher } from '../../../../_events'
+
+import { UseProgressModeButtonReturn } from './index.types'
+
+/**
+ * ProgressModeButton の操作ロジック
+ */
+export const useProgressModeButton = (): UseProgressModeButtonReturn => {
+  const progressMode = useTimeControl03Computed((state) => state.progressMode)
+
+  const timeControl03EventDispatcher = useTimeControl03EventDispatcher()
+
+  const toggleProgressMode: UseProgressModeButtonReturn['toggleProgressMode'] =
+    timeControl03EventDispatcher['TimeControl03-toggle-progress-mode']
+
+  return { progressMode, toggleProgressMode }
+}

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_components/progress-mode-button/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_components/progress-mode-button/index.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@/components/ui/button'
+
+import { useProgressModeButton } from './index.hooks'
+
+/**
+ * 進行モード (auto/manual) 全 actor 一括切替ボタン
+ *
+ * - progressMode 購読をここに閉じ込め、`ActionBar` 本体・他ボタンの再レンダリングを避ける
+ */
+export const ProgressModeButton = () => {
+  const { progressMode, toggleProgressMode } = useProgressModeButton()
+
+  return (
+    <Button onClick={toggleProgressMode} type="button" variant="outline">
+      mode: {progressMode}
+    </Button>
+  )
+}

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/_components/progress-mode-button/index.types.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/_components/progress-mode-button/index.types.ts
@@ -1,0 +1,8 @@
+import { ProgressMode } from '../../../../types'
+
+export type UseProgressModeButtonReturn = {
+  /** 進行モード (auto/manual) */
+  progressMode: ProgressMode
+  /** 進行モード全 actor 一括切替 */
+  toggleProgressMode: () => void
+}

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/index.hooks.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/index.hooks.ts
@@ -1,4 +1,3 @@
-import { useTimeControl03Computed } from '../../_computed'
 import { useTimeControl03EventDispatcher } from '../../_events'
 
 import { UseActionBarReturn } from './index.types'
@@ -7,8 +6,6 @@ import { UseActionBarReturn } from './index.types'
  * ActionBar の操作ロジック
  */
 export const useActionBar = (): UseActionBarReturn => {
-  const progressMode = useTimeControl03Computed((state) => state.progressMode)
-
   const timeControl03EventDispatcher = useTimeControl03EventDispatcher()
 
   const dispatchDecision: UseActionBarReturn['dispatchDecision'] =
@@ -17,13 +14,8 @@ export const useActionBar = (): UseActionBarReturn => {
   const resetAll: UseActionBarReturn['resetAll'] =
     timeControl03EventDispatcher['TimeControl03-reset-all']
 
-  const toggleProgressMode: UseActionBarReturn['toggleProgressMode'] =
-    timeControl03EventDispatcher['TimeControl03-toggle-progress-mode']
-
   return {
     dispatchDecision,
-    progressMode,
     resetAll,
-    toggleProgressMode,
   }
 }

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/index.tsx
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 
 import { AsyncSampleButton } from './_components/async-sample-button'
+import { ProgressModeButton } from './_components/progress-mode-button'
 import { useActionBar } from './index.hooks'
 
 /**
@@ -13,17 +14,14 @@ import { useActionBar } from './index.hooks'
  * - async sample: async listener 実演用サンプルイベント発行
  */
 export const ActionBar = () => {
-  const { dispatchDecision, progressMode, resetAll, toggleProgressMode } =
-    useActionBar()
+  const { dispatchDecision, resetAll } = useActionBar()
 
   return (
     <div className="flex gap-2 p-2">
       <Button onClick={dispatchDecision} type="button">
         行動決定
       </Button>
-      <Button onClick={toggleProgressMode} type="button" variant="outline">
-        mode: {progressMode}
-      </Button>
+      <ProgressModeButton />
       <Button onClick={resetAll} type="button" variant="destructive">
         reset
       </Button>

--- a/src/prototypes/time-control/time-control-03/_components/action-bar/index.types.ts
+++ b/src/prototypes/time-control/time-control-03/_components/action-bar/index.types.ts
@@ -1,12 +1,6 @@
-import { ProgressMode } from '../../types'
-
 export type UseActionBarReturn = {
   /** 行動決定実行 */
   dispatchDecision: () => void
-  /** 進行モード (auto/manual) */
-  progressMode: ProgressMode
   /** 全 store reset */
   resetAll: () => void
-  /** 進行モード全 actor 一括切替 */
-  toggleProgressMode: () => void
 }

--- a/src/prototypes/time-control/time-control-03/_computed/index.contexts.tsx
+++ b/src/prototypes/time-control/time-control-03/_computed/index.contexts.tsx
@@ -11,8 +11,13 @@ import { ComputedState } from './types'
 const { StoreContext, useStoreSelector } =
   createStoreContext<ComputedState>('Computed')
 
+/** Computed store 用 Context */
 export const ComputedStoreContext = StoreContext
-export const useTimeControl03Computed = useStoreSelector
+
+/** Computed store を selector 購読する */
+export const useTimeControl03Computed = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)
 
 /**
  * props (actorIds)・store (actor-settings/planned-path) から算出する派生値を生成し配布する

--- a/src/prototypes/time-control/time-control-03/_events/_contexts/scope-event-context.ts
+++ b/src/prototypes/time-control/time-control-03/_events/_contexts/scope-event-context.ts
@@ -1,8 +1,8 @@
 import { createRequiredContext } from '@/utils/create-required-context'
 
 export const {
-  Context: ScopeEventContext,
-  useContextValue: useScopeEventTarget,
+  RequiredContext: ScopeEventContext,
+  useRequiredContext: useScopeEventTarget,
 } = createRequiredContext<EventTarget>(
   'useScopeEventTarget should be used within <ScopeEventProvider>',
 )

--- a/src/prototypes/time-control/time-control-03/_events/_contexts/scope-event-context.ts
+++ b/src/prototypes/time-control/time-control-03/_events/_contexts/scope-event-context.ts
@@ -1,8 +1,12 @@
 import { createRequiredContext } from '@/utils/create-required-context'
 
-export const {
-  RequiredContext: ScopeEventContext,
-  useRequiredContext: useScopeEventTarget,
-} = createRequiredContext<EventTarget>(
-  'useScopeEventTarget should be used within <ScopeEventProvider>',
-)
+const { RequiredContext, useRequiredContext } =
+  createRequiredContext<EventTarget>(
+    'useScopeEventTarget should be used within <ScopeEventProvider>',
+  )
+
+/** scope event 用 Context */
+export const ScopeEventContext = RequiredContext
+
+/** scope event の発火対象 (EventTarget) を取得する */
+export const useScopeEventTarget = (): EventTarget => useRequiredContext()

--- a/src/prototypes/time-control/time-control-03/_stores/actor-settings/context.tsx
+++ b/src/prototypes/time-control/time-control-03/_stores/actor-settings/context.tsx
@@ -1,3 +1,5 @@
+import { StoreApi } from 'zustand/vanilla'
+
 import { createStoreContext } from '@/stores/utils/create-store-context'
 
 import { ActorSettingsState } from './types'
@@ -5,8 +7,13 @@ import { ActorSettingsState } from './types'
 const { StoreContext, useStoreApi, useStoreSelector } =
   createStoreContext<ActorSettingsState>('ActorSettings')
 
+/** ActorSettings store 用 Context */
 export const ActorSettingsStoreContext = StoreContext
-export const useActorSettingsStore = useStoreSelector
+
+/** ActorSettings store を selector 購読する */
+export const useActorSettingsStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)
 
 /**
  * 生の store を返す
@@ -14,4 +21,5 @@ export const useActorSettingsStore = useStoreSelector
  * - `_computed` 等、他 store から算出する派生値の store 生成 (`store.subscribe` +\
  *   `store.getState()`) 向け
  */
-export const useActorSettingsStoreApi = useStoreApi
+export const useActorSettingsStoreApi = (): StoreApi<ActorSettingsState> =>
+  useStoreApi()

--- a/src/prototypes/time-control/time-control-03/_stores/actor/context.tsx
+++ b/src/prototypes/time-control/time-control-03/_stores/actor/context.tsx
@@ -5,5 +5,10 @@ import { ActorState } from './types'
 const { StoreContext, useStoreSelector } =
   createStoreContext<ActorState>('Actor')
 
+/** Actor store 用 Context */
 export const ActorStoreContext = StoreContext
-export const useActorStore = useStoreSelector
+
+/** Actor store を selector 購読する */
+export const useActorStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)

--- a/src/prototypes/time-control/time-control-03/_stores/game-clock/context.tsx
+++ b/src/prototypes/time-control/time-control-03/_stores/game-clock/context.tsx
@@ -5,5 +5,10 @@ import { GameClockState } from './types'
 const { StoreContext, useStoreSelector } =
   createStoreContext<GameClockState>('GameClock')
 
+/** GameClock store 用 Context */
 export const GameClockStoreContext = StoreContext
-export const useGameClockStore = useStoreSelector
+
+/** GameClock store を selector 購読する */
+export const useGameClockStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)

--- a/src/prototypes/time-control/time-control-03/_stores/intent/context.tsx
+++ b/src/prototypes/time-control/time-control-03/_stores/intent/context.tsx
@@ -5,5 +5,10 @@ import { IntentState } from './types'
 const { StoreContext, useStoreSelector } =
   createStoreContext<IntentState>('Intent')
 
+/** Intent store 用 Context */
 export const IntentStoreContext = StoreContext
-export const useIntentStore = useStoreSelector
+
+/** Intent store を selector 購読する */
+export const useIntentStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)

--- a/src/prototypes/time-control/time-control-03/_stores/path/context.tsx
+++ b/src/prototypes/time-control/time-control-03/_stores/path/context.tsx
@@ -4,5 +4,10 @@ import { PathState } from './types'
 
 const { StoreContext, useStoreSelector } = createStoreContext<PathState>('Path')
 
+/** Path store 用 Context */
 export const PathStoreContext = StoreContext
-export const usePathStore = useStoreSelector
+
+/** Path store を selector 購読する */
+export const usePathStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)

--- a/src/prototypes/time-control/time-control-03/_stores/planned-path/context.tsx
+++ b/src/prototypes/time-control/time-control-03/_stores/planned-path/context.tsx
@@ -1,3 +1,5 @@
+import { StoreApi } from 'zustand/vanilla'
+
 import { createStoreContext } from '@/stores/utils/create-store-context'
 
 import { PlannedPathState } from './types'
@@ -5,8 +7,13 @@ import { PlannedPathState } from './types'
 const { StoreContext, useStoreApi, useStoreSelector } =
   createStoreContext<PlannedPathState>('PlannedPath')
 
+/** PlannedPath store 用 Context */
 export const PlannedPathStoreContext = StoreContext
-export const usePlannedPathStore = useStoreSelector
+
+/** PlannedPath store を selector 購読する */
+export const usePlannedPathStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)
 
 /**
  * 生の store を返す
@@ -14,4 +21,5 @@ export const usePlannedPathStore = useStoreSelector
  * - `_computed` 等、他 store から算出する派生値の store 生成 (`store.subscribe` +\
  *   `store.getState()`) 向け
  */
-export const usePlannedPathStoreApi = useStoreApi
+export const usePlannedPathStoreApi = (): StoreApi<PlannedPathState> =>
+  useStoreApi()

--- a/src/prototypes/time-control/time-control-03/_stores/position/context.tsx
+++ b/src/prototypes/time-control/time-control-03/_stores/position/context.tsx
@@ -1,3 +1,5 @@
+import { StoreApi } from 'zustand/vanilla'
+
 import { createStoreContext } from '@/stores/utils/create-store-context'
 
 import { PositionState } from './types'
@@ -5,8 +7,13 @@ import { PositionState } from './types'
 const { StoreContext, useStoreApi, useStoreSelector } =
   createStoreContext<PositionState>('Position')
 
+/** Position store 用 Context */
 export const PositionStoreContext = StoreContext
-export const usePositionStore = useStoreSelector
+
+/** Position store を selector 購読する */
+export const usePositionStore = <T,>(
+  ...args: Parameters<typeof useStoreSelector<T>>
+): T => useStoreSelector(...args)
 
 /**
  * 生の store を返す
@@ -14,4 +21,4 @@ export const usePositionStore = useStoreSelector
  * - React の再レンダリングを経由せず ref 経由で DOM を直接更新する購読\
  *   (`store.subscribe` + `store.getState()`) 向け
  */
-export const usePositionStoreApi = useStoreApi
+export const usePositionStoreApi = (): StoreApi<PositionState> => useStoreApi()

--- a/src/prototypes/time-control/time-control-03/index.contexts.tsx
+++ b/src/prototypes/time-control/time-control-03/index.contexts.tsx
@@ -2,7 +2,11 @@ import { createPropsContext } from '@/utils/create-props-context'
 
 import { TimeControl03Props } from './index.types'
 
-export const {
-  Provider: TimeControl03PropsProvider,
-  useProps: useTimeControl03Props,
-} = createPropsContext<TimeControl03Props>('TimeControl03')
+const { Provider, useProps } =
+  createPropsContext<TimeControl03Props>('TimeControl03')
+
+/** TimeControl03 props 配布用 Provider */
+export const TimeControl03PropsProvider = Provider
+
+/** TimeControl03 props を取得する */
+export const useTimeControl03Props = (): TimeControl03Props => useProps()

--- a/src/stores/utils/create-store-context.ts
+++ b/src/stores/utils/create-store-context.ts
@@ -15,7 +15,7 @@ import { createRequiredContext } from '@/utils/create-required-context'
  * @param storeName store 名 (例: `ActorSettings`)。エラーメッセージの hook 名・Context 名生成に使う
  */
 export const createStoreContext = <State>(storeName: string) => {
-  const { Context: StoreContext, useContextValue: useStoreApi } =
+  const { RequiredContext: StoreContext, useRequiredContext: useStoreApi } =
     createRequiredContext<StoreApi<State>>(
       `use${storeName}Store should be used within <${storeName}StoreContext.Provider>`,
     )

--- a/src/utils/create-props-context.tsx
+++ b/src/utils/create-props-context.tsx
@@ -13,15 +13,17 @@ import { createRequiredContext } from './create-required-context'
  * @param name Provider/hook の対象名 (例: `'TimeControl03'`)
  */
 export const createPropsContext = <Props extends object>(name: string) => {
-  const { Context, useContextValue } = createRequiredContext<
+  const { RequiredContext, useRequiredContext } = createRequiredContext<
     PropsWithChildren<Props>
   >(`use${name}Props should be used within <${name}Providers>`)
 
   const Provider = (props: PropsWithChildren<Props>) => (
-    <Context.Provider value={props}>{props.children}</Context.Provider>
+    <RequiredContext.Provider value={props}>
+      {props.children}
+    </RequiredContext.Provider>
   )
 
-  const useProps = (): Props => useContextValue()
+  const useProps = (): Props => useRequiredContext()
 
   return { Provider, useProps }
 }

--- a/src/utils/create-required-context.ts
+++ b/src/utils/create-required-context.ts
@@ -8,10 +8,10 @@ import { createContext, useContext } from 'react'
  * @param errorMessage 未 Provider 時に throw するエラーメッセージ
  */
 export const createRequiredContext = <Value>(errorMessage: string) => {
-  const Context = createContext<null | Value>(null)
+  const RequiredContext = createContext<null | Value>(null)
 
-  const useContextValue = (): Value => {
-    const value = useContext(Context)
+  const useRequiredContext = (): Value => {
+    const value = useContext(RequiredContext)
 
     if (value === null) {
       throw new Error(errorMessage)
@@ -20,5 +20,5 @@ export const createRequiredContext = <Value>(errorMessage: string) => {
     return value
   }
 
-  return { Context, useContextValue }
+  return { RequiredContext, useRequiredContext }
 }


### PR DESCRIPTION
## Summary

- `createRequiredContext` の `useContextValue`/`Context` を `useRequiredContext`/`RequiredContext` に改名し、React 標準 `useContext` との名前衝突を回避
- ActionBar の mode 切替ボタンを `ProgressModeButton` へ切出し、`progressMode` 変更による ActionBar 全体の無関係な re-render を解消
- `create~Context` 系呼び出し箇所 (`export const useX = useY` の直接代入) を関数ラップに変更し、エディタの定義ジャンプが各 store/context 側に効くようにした。併せて JSDoc の欠落箇所へ簡潔な説明を付与

## Test plan

- [x] `yarn tsc --noEmit`
- [x] `yarn eslint` (対象ファイル)